### PR TITLE
Simpler import: `import configargparse`

### DIFF
--- a/configargparse.py
+++ b/configargparse.py
@@ -10,7 +10,7 @@ if sys.version_info >= (3, 0):
 else:
     from StringIO import StringIO
 
-__version__ = "0.9"
+__version__ = "0.9.2"
 
 
 ACTION_TYPES_THAT_DONT_NEED_A_VALUE = {argparse._StoreTrueAction,
@@ -508,6 +508,3 @@ argparse._ActionsContainer.add = argparse._ActionsContainer.add_argument
 
 ArgumentParser.parse = ArgumentParser.parse_args
 ArgumentParser.parse_known = ArgumentParser.parse_known_args
-
-
-

--- a/configargparse/__init__.py
+++ b/configargparse/__init__.py
@@ -1,4 +1,0 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-__version__ = '0.9.1'

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-import configargparse 
+import configargparse
 import logging
 import os
 import sys
@@ -12,61 +12,61 @@ except ImportError:
 
 def launch_http_server(directory):
     assert os.path.isdir(directory)
-    
+
     try:
         try:
             from SimpleHTTPServer import SimpleHTTPRequestHandler
         except ImportError:
             from http.server import SimpleHTTPRequestHandler
-        
-        try: 
+
+        try:
             import SocketServer
-        except ImportError: 
+        except ImportError:
             import socketserver as SocketServer
-        
+
         import socket
-    
+
         for port in [80] + list(range(8000, 8100)):
             try:
                 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 s.bind(('localhost', port))
                 s.close()
             except socket.error as e:
-                logging.debug("Can't use port %d: %s" % (port, e.strerror))            
-                continue        
-            
+                logging.debug("Can't use port %d: %s" % (port, e.strerror))
+                continue
+
             print("HTML coverage report now available at http://%s%s" % (
                 socket.gethostname(), (":%s" % port) if port != 80 else ""))
-            
+
             os.chdir(directory)
-            SocketServer.TCPServer(("", port), 
+            SocketServer.TCPServer(("", port),
                 SimpleHTTPRequestHandler).serve_forever()
         else:
-            logging.debug("All network port. ")    
+            logging.debug("All network port. ")
     except Exception as e:
-        logging.error("ERROR: while starting an HTTP server to serve " 
+        logging.error("ERROR: while starting an HTTP server to serve "
                       "the coverage report: %s" % e)
-    
-    
+
+
 command = sys.argv[-1]
 if command == 'publish':
     os.system('python setup.py sdist upload')
     sys.exit()
 elif command == "coverage":
-    try: 
+    try:
         import coverage
     except:
         sys.exit("coverage.py not installed (pip install --user coverage)")
     setup_py_path = os.path.abspath(__file__)
-    os.system('coverage run --source=configargparse ' + setup_py_path +' test')    
+    os.system('coverage run ' + setup_py_path +' test')
     os.system('coverage report')
-    os.system('coverage html')    
+    os.system('coverage html')
     print("Done computing coverage")
     launch_http_server(directory="htmlcov")
     sys.exit()
 
 try:
-    import pypandoc 
+    import pypandoc
     if os.path.isfile('README.md'):
         long_description = pypandoc.convert(open('README.md').read(), 'rst', format='md')
     else:
@@ -86,18 +86,16 @@ setup(
     author='Zorro',
     author_email='zorro3.github@gmail.com',
     url='https://github.com/zorro3/ConfigArgParse',
-    packages=['configargparse'],
-    package_dir={'configargparse': 'configargparse'},
     include_package_data=True,
     install_requires=[],
-    license="MIT",    
+    license="MIT",
     keywords='options, argparse, ConfigArgParse, config, environment variables, envvars, ENV, environment, optparse',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
-        "Programming Language :: Python :: 2",        
+        "Programming Language :: Python :: 2",
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.2',


### PR DESCRIPTION
Because this package is in one file, convention would suggest putting it
in the project's root directory to avoid the duplication in `from
configargparse import configargparse` (see
https://github.com/defnull/bottle as an example).
