### PR TITLE
Ensure auto_env_var_prefix converts dash to underscore like ArgParse

### DIFF
--- a/configargparse.py
+++ b/configargparse.py
@@ -125,6 +125,8 @@ class ArgumentParser(argparse.ArgumentParser):
                 variables whose names are this prefix followed by the config
                 file key, all in upper case. (eg. setting this to "foo_" will
                 allow an arg like "--arg1" to also be set via env. var FOO_ARG1)
+                Any dashes in the arg name are turned into undescores to
+                confirm with ArgParse.
             config_file_parser: An instance of a parser to be used for parsing
                 config files. Default: ConfigFileParser()
             default_config_files: When specified, this list of config files will
@@ -254,7 +256,7 @@ class ArgumentParser(argparse.ArgumentParser):
                     stripped_config_file_key = config_file_keys[0].strip(
                         self.prefix_chars)
                     a.env_var = (self._auto_env_var_prefix +
-                                 stripped_config_file_key).upper()
+                                 stripped_config_file_key).replace('-', '_').upper()
 
         # add env var settings to the commandline that aren't there already
         env_var_args = []

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ if sys.version_info < (2, 7):
 
 setup(
     name='ConfigArgParse',
-    version="0.9.4",
+    version="0.10.0",
     description='A drop-in replacement for argparse that allows options to also be set via config files and/or environment variables.',
     long_description=long_description,
     author='Zorro',

--- a/tests/test_configargparse.py
+++ b/tests/test_configargparse.py
@@ -497,18 +497,21 @@ class TestBasicUseCases(TestCase):
         self.add_arg("-x", "--arg2", env_var="TEST2", type=int)
         self.add_arg("-y", "--arg3", action="append", type=int)
         self.add_arg("-z", "--arg4", required=True)
+        self.add_arg("-w", "--arg4-more", required=True)
         ns = self.parse("", env_vars = {
             "TEST_ARG0": "0",
             "TEST_ARG1": "1",
             "TEST_ARG2": "2",
             "TEST2": "22",
             "TEST_ARG3": "[1,2,3]",
-            "TEST_ARG4": "arg4_value"})
+            "TEST_ARG4": "arg4_value",
+            "TEST_ARG4_MORE": "magic"})
         self.assertEqual(ns.arg0, None)
         self.assertEqual(ns.arg1, None)
         self.assertEqual(ns.arg2, 22)
         self.assertListEqual(ns.arg3, [1,2,3])
         self.assertEqual(ns.arg4, "arg4_value")
+        self.assertEqual(ns.arg4_more, "magic")
 
 class TestMisc(TestCase):
     # TODO test different action types with config file, env var


### PR DESCRIPTION
From https://docs.python.org/dev/library/argparse.html#dest: Any internal - characters will be converted to _ characters to make sure the string is a valid attribute name

Also bumped the version to `0.10.0` to be more semvar since `0.9.4` was really feature addition.