### PR TITLE
Moved all syntax-related decisions to ConfigFileParser subclasses. Added YAMLConfigFileParser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ output/*/index.html
 
 # Sphinx
 docs/_build
+
+# IDEs
+.idea

--- a/README.rst
+++ b/README.rst
@@ -139,8 +139,12 @@ Config File Syntax
 
 Only command line args that have a long version (eg. one that starts with '--')
 can be set in a config file. For example, "--color" can be set by
-putting "color=green" in a config file. The full range of valid config
-file syntax is:
+putting "color=green" in a config file. The config file syntax depends on the
+constuctor arg: :code:`config_file_parser_class` which can be set to one of the
+provided classes: :code:`DefaultConfigFileParser` or :code:`YAMLConfigFileParser`,
+or to your own subclass of the :code:`ConfigFileParser` abstract class.
+
+*DefaultConfigFileParser*  - the full range of valid syntax is:
 
 .. code:: yaml
 
@@ -164,6 +168,19 @@ file syntax is:
         # how to specify a list arg (eg. arg which has action="append")
         fruit = [apple, orange, lemon]
         indexes = [1, 12, 35 , 40]
+
+
+*YAMLConfigFileParser*  - allows a subset of YAML syntax (http://goo.gl/VgT2DU)
+
+.. code:: yaml
+
+        # a comment
+        name1: value
+        name2: true    # "True" and "true" are the same
+
+        fruit: [apple, orange, lemon]
+        indexes: [1, 12, 35, 40]
+
 
 ArgParser Singletons
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -9,33 +9,31 @@ Python's command line parsing modules such as argparse have very limited
 support for config files and environment variables, so this module
 extends argparse to add these features.
 
-|Travis CI Status for bw2/ConfigArgParse|  -- from `Travis CI <https://travis-ci.org/bw2/ConfigArgParse/>`_ 
+|Travis CI Status for bw2/ConfigArgParse|  -- from `Travis CI <https://travis-ci.org/bw2/ConfigArgParse/>`_
 
 Features
 ~~~~~~~~
 
 -  command-line, config file, env var, and default settings can now be
-   defined, documented, and parsed in one go using a single API (if a 
-   value is specified in more than one way then: command line > 
+   defined, documented, and parsed in one go using a single API (if a
+   value is specified in more than one way then: command line >
    environment variables > config file values > defaults)
 -  config files can have .ini or .yaml style syntax (eg. key=value or
    key: value)
 -  user can provide a config file via a normal-looking command line arg
    (eg. -c path/to/config.txt) rather than the argparse-style @config.txt
--  one or more default config file paths can be specified 
+-  one or more default config file paths can be specified
    (eg. ['/etc/bla.conf', '~/.my_config'] )
 -  all argparse functionality is fully supported, so this module can
    serve as a drop-in replacement (verified by argparse unittests).
 -  env vars and config file keys & syntax are automatically documented
    in the -h help message
--  new method :code:`print_values()` can report keys & values and where 
+-  new method :code:`print_values()` can report keys & values and where
    they were set (eg. command line, env var, config file, or default).
--  lite-weight (no dependencies on 3rd-party libraries)
--  extensible (the following methods can be over-ridden to change how 
-   config files and environment variable values are parsed: 
-   :code:`parse_config_file()`, :code:`get_possible_config_keys()`, 
-   :code:`convert_setting_to_command_line_arg()`
--  unittested by running the unittests that came with argparse but on 
+-  lite-weight (no 3rd-party library dependencies except (optionally) PyYAML)
+-  extensible (:code:`ConfigFileParser` can be subclassed to define a new
+   config file format)
+-  unittested by running the unittests that came with argparse but on
    configargparse, and using tox to test with python2.7+ and python3+
 
 Example
@@ -43,14 +41,14 @@ Example
 
 *my_script.py*:
 
-Script that defines 4 options and a positional arg and then parses and prints the values. Also, 
-it prints out the help message as well as the string produced by :code:`format_values()` to show 
-what they look like. 
+Script that defines 4 options and a positional arg and then parses and prints the values. Also,
+it prints out the help message as well as the string produced by :code:`format_values()` to show
+what they look like.
 
 .. code:: py
 
    import configargparse
-    
+
    p = configargparse.ArgParser(default_config_files=['/etc/settings.ini', '~/.my_settings'])
    p.add('-c', '--my-config', required=True, is_config_file=True, help='config file path')
    p.add('--genome', required=True, help='path to genome file')  # this option can be set in a config file because it starts with '--'
@@ -59,7 +57,7 @@ what they look like.
    p.add('vcf', nargs='+', help='variant file(s)')
 
    options = p.parse_args()
-   
+
    print(options)
    print("----------")
    print(p.format_help())
@@ -122,18 +120,18 @@ Special Values
 
 Under the hood, configargparse handles environment variables and config file
 values by converting them to their corresponding command line arg. For
-example, "key = value" will be processed as if "--key value" was specified 
+example, "key = value" will be processed as if "--key value" was specified
 on the command line.
 
 Also, the following special values (whether in a config file or an environment
 variable) are handled in a special way to support booleans and lists:
 
 -  :code:`key = true` is handled as if "--key" was specified on the command line.
-   In your python code this key must be defined as a boolean flag 
+   In your python code this key must be defined as a boolean flag
    (eg. action="store_true" or similar).
 
 -  :code:`key = [value1, value2, ...]` is handled as if "--key value1 --key value2"
-   etc. was specified on the command line. In your python code this key must 
+   etc. was specified on the command line. In your python code this key must
    be defined as a list (eg. action="append").
 
 Config File Syntax
@@ -170,12 +168,12 @@ file syntax is:
 ArgParser Singletons
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To make it easier to configure different modules in an application, 
-configargparse provides globally-available ArgumentParser instances 
-via configargparse.getArgumentParser('name') (similar to 
-logging.getLogger('name')). 
+To make it easier to configure different modules in an application,
+configargparse provides globally-available ArgumentParser instances
+via configargparse.getArgumentParser('name') (similar to
+logging.getLogger('name')).
 
-Here is an example of an application with a utils module that also 
+Here is an example of an application with a utils module that also
 defines and retrieves its own command-line args.
 
 *main.py*
@@ -197,16 +195,16 @@ defines and retrieves its own command-line args.
     import configargparse
     p = configargparse.getArgumentParser()
     p.add_argument("--utils-setting", help="Config-file-settable option for utils")
-    
+
     if __name__ == "__main__":
        options = p.parse_known_args()
 
 Help Formatters
 ~~~~~~~~~~~~~~~
 
-:code:`ArgumentDefaultsRawHelpFormatter`  A new HelpFormatter (to be passed to the 
-ArgumentParser constructor's formatter_class arg) which adds default values AND 
-disables line-wrapping.
+:code:`ArgumentDefaultsRawHelpFormatter` is a new HelpFormatter that both adds
+default values AND disables line-wrapping. It can be passed to the constructor:
+:code:`ArgParser(.., formatter_class=ArgumentDefaultsRawHelpFormatter)`
 
 
 Aliases
@@ -217,7 +215,7 @@ names from argparse and also provides the following shorter names for
 convenience:
 
 -  p = configargparse.getArgParser()  # get global singleton instance
--  p = configargparse.getParser()  
+-  p = configargparse.getParser()
 -  p = configargparse.ArgParser()  # create a new instance
 -  p = configargparse.Parser()
 -  p.add_arg(..)

--- a/configargparse.py
+++ b/configargparse.py
@@ -483,7 +483,7 @@ class ArgumentParser(argparse.ArgumentParser):
             config_streams = self._open_config_files(args)
 
         # parse each config file
-        for stream in config_streams[::-1]:
+        for stream in reversed(config_streams):
             try:
                 config_items = self._config_file_parser.parse(stream)
             except ConfigFileParserException as e:

--- a/configargparse.py
+++ b/configargparse.py
@@ -282,7 +282,6 @@ class ArgumentParser(argparse.ArgumentParser):
 
         default_config_files=[],
         ignore_unknown_config_file_keys=False,
-        allow_unknown_config_file_keys=False,  # deprecated
         config_file_parser_class=DefaultConfigFileParser,
 
         args_for_setting_config_path=[],
@@ -367,8 +366,7 @@ class ArgumentParser(argparse.ArgumentParser):
             self._config_file_parser = config_file_parser_class()
 
         self._default_config_files = default_config_files
-        self._ignore_unknown_config_file_keys = ignore_unknown_config_file_keys \
-                                            or allow_unknown_config_file_keys
+        self._ignore_unknown_config_file_keys = ignore_unknown_config_file_keys
         if args_for_setting_config_path:
             self.add_argument(*args_for_setting_config_path, dest="config_file",
                 required=config_arg_is_required, help=config_arg_help_message,

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ if sys.version_info < (2, 7):
 
 setup(
     name='ConfigArgParse',
-    version="0.10.1",
+    version="0.11.0",
     description='A drop-in replacement for argparse that allows options to also be set via config files and/or environment variables.',
     long_description=long_description,
     author='Zorro',

--- a/setup.py
+++ b/setup.py
@@ -80,15 +80,17 @@ if sys.version_info < (2, 7):
 setup(
     name='ConfigArgParse',
     version="0.11.0",
-    description='A drop-in replacement for argparse that allows options to also be set via config files and/or environment variables.',
+    description='A drop-in replacement for argparse that allows options to '
+                'also be set via config files and/or environment variables.',
     long_description=long_description,
     author='Zorro',
     author_email='zorro3.github@gmail.com',
-    url='https://github.com/zorro3/ConfigArgParse',
+    url='https://github.com/bw2/ConfigArgParse',
     py_modules=['configargparse'],
     include_package_data=True,
     license="MIT",
-    keywords='options, argparse, ConfigArgParse, config, environment variables, envvars, ENV, environment, optparse',
+    keywords='options, argparse, ConfigArgParse, config, environment variables, '
+             'envvars, ENV, environment, optparse, YAML, INI',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
@@ -107,4 +109,7 @@ setup(
     ],
     test_suite='tests',
     install_requires=install_requires,
+    extras_require = {
+        'yaml': ["PyYAML"],
+    }
 )

--- a/tests/test_configargparse.py
+++ b/tests/test_configargparse.py
@@ -446,7 +446,7 @@ class TestBasicUseCases(TestCase):
         self.initParser(allow_unknown_config_file_keys=False)
         ns, args = self.parse_known(args="-x 1", config_file_contents="bla=3",
             env_vars={"bla": "2"})
-        self.assertListEqual(args, ["-x", "1", "--bla", "3"])
+        self.assertListEqual(args, ["--bla", "3", "-x", "1"])
 
     def testConfigOrEnvValueErrors(self):
         # error should occur when a flag arg is set to something other than "true" or "false"
@@ -785,13 +785,12 @@ else:
     exec(test_argparse_source_code)
 
     # print argparse unittest source code
-    #def print_source_code(source_code, line_numbers, context_lines=10):
-    #     for n in line_numbers:
-    #         logging.debug("##### Code around line %s #####" % n)
-    #         lines_to_print = set(range(n - context_lines, n + context_lines))
-    #         for n2, line in enumerate(source_code.split("\n"), 1):
-    #             if n2 in lines_to_print:
-    #                 logging.debug("%s %5d: %s" % (
-    #                    "**" if n2 == n else "  ", n2, line))
-    #     #sys.exit()
+    def print_source_code(source_code, line_numbers, context_lines=10):
+         for n in line_numbers:
+             logging.debug("##### Code around line %s #####" % n)
+             lines_to_print = set(range(n - context_lines, n + context_lines))
+             for n2, line in enumerate(source_code.split("\n"), 1):
+                 if n2 in lines_to_print:
+                     logging.debug("%s %5d: %s" % (
+                        "**" if n2 == n else "  ", n2, line))
     #print_source_code(test_argparse_source_code, [4540, 4565])

--- a/tests/test_configargparse.py
+++ b/tests/test_configargparse.py
@@ -443,7 +443,7 @@ class TestBasicUseCases(TestCase):
                         env_vars={"bla": "2"})
         self.assertListEqual(args, ["--bla", "3"])
 
-        self.initParser(allow_unknown_config_file_keys=False)
+        self.initParser(ignore_unknown_config_file_keys=False)
         ns, args = self.parse_known(args="-x 1", config_file_contents="bla=3",
             env_vars={"bla": "2"})
         self.assertListEqual(args, ["--bla", "3", "-x", "1"])
@@ -553,7 +553,6 @@ class TestMisc(TestCase):
     def testConstructor_ConfigFileArgs(self):
         # Test constructor args:
         #   args_for_setting_config_path
-        #   allow_unknown_config_file_keys
         #   config_arg_is_required
         #   config_arg_help_message
         temp_cfg = tempfile.NamedTemporaryFile(mode="w", delete=True)


### PR DESCRIPTION
Hi @cortesi @lahwaacz @acx2015 @bartekbrak @kuba (and anyone else interested), 
It'd be great to get your feedback on this PR which builds on @lahwaacz 's PR #28. It moves all remaining logic involving config file formats into `ConfigFileParser` subclasses. The format can then be specified by just setting the new `config_file_parser_class` constructor arg (similar to HelpFormatters). Also, there's now a new `YAMLConfigFileParser` as an alternative to the `DefaultConfigFileParser`. 

Depending on feedback (or if there's none during the next week), I'll merge this and create a new release (probably v1.0). 

This should also fix #19 and #30 (and also #26 - the fix for that became clear while working on this). 

