### PR TITLE
Fix config help when there are no config args

### DIFF
--- a/configargparse.py
+++ b/configargparse.py
@@ -809,7 +809,7 @@ class ArgumentParser(argparse.ArgumentParser):
                     config_arg_string = "specified via " + config_arg_string
                 if default_config_files or config_arg_string:
                     msg += " (%s)." % " or ".join(default_config_files +
-                                                 [config_arg_string])
+                                                  list(filter(None, [config_arg_string])))
                 msg += " " + self._config_file_parser.get_syntax_description()
 
         if self._add_env_var_help:


### PR DESCRIPTION
When there are no config args, config_arg_string is the empty string.
Run the list through filter to remove the empty string and fix the help
output.

Fixes #40