### PR TITLE
Allow whitespace within values in all cases

### DIFF
--- a/configargparse.py
+++ b/configargparse.py
@@ -152,8 +152,7 @@ class DefaultConfigFileParser(ConfigFileParser):
                 continue
             white_space = "\\s*"
             key = "(?P<key>[^:=;#\s]+?)"
-            value1 = white_space+"[:=]"+white_space+"(?P<value>[^;#]+?)"
-            value2 = white_space+"[\s]"+white_space+"(?P<value>[^;#\s]+?)"
+            value = white_space+"[:=\s]"+white_space+"(?P<value>[^;#]+?)"
             comment = white_space+"(?P<comment>\\s[;#].*)?"
 
             key_only_match = re.match("^" + key + comment + "$", line)
@@ -162,8 +161,7 @@ class DefaultConfigFileParser(ConfigFileParser):
                 items[key] = "true"
                 continue
 
-            key_value_match = re.match("^"+key+value1+comment+"$", line) or \
-                              re.match("^"+key+value2+comment+"$", line)
+            key_value_match = re.match("^"+key+value+comment+"$", line)
             if key_value_match:
                 key = key_value_match.group("key")
                 value = key_value_match.group("value")

--- a/tests/test_configargparse.py
+++ b/tests/test_configargparse.py
@@ -372,6 +372,7 @@ class TestBasicUseCases(TestCase):
         self.add_arg('-x', required=True, type=int)
         self.add_arg('--y', required=True, type=float)
         self.add_arg('--z')
+        self.add_arg('--c')
         self.add_arg('--b', action="store_true")
         self.add_arg('--a', action="append", type=int)
 
@@ -407,11 +408,14 @@ class TestBasicUseCases(TestCase):
         b: True
         ----
         a = 33
+        ---
+        z z 1
         """)
 
         self.assertEqual(ns.x, 1)
         self.assertEqual(ns.y, 12.1)
-        self.assertEqual(ns.z, None)
+        self.assertEqual(ns.z, 'z 1')
+        self.assertEqual(ns.c, None)
         self.assertEqual(ns.b, True)
         self.assertEqual(ns.a, [33])
         self.assertRegex(self.format_values(),
@@ -419,7 +423,9 @@ class TestBasicUseCases(TestCase):
             'Config File \(method arg\):\n'
             '  y: \s+ 12.1\n'
             '  b: \s+ True\n'
-            '  a: \s+ 33\n')
+            '  a: \s+ 33\n'
+            '  z: \s+ z 1\n')
+
 
         # -x is not a long arg so can't be set via config file
         self.assertParseArgsRaises("argument -x is required"
@@ -435,7 +441,7 @@ class TestBasicUseCases(TestCase):
                                    args="-x 5",
                                    config_file_contents="z: 1")
         self.assertParseArgsRaises("Unexpected line 0",
-                                   config_file_contents="z z 1")
+                                   config_file_contents="z z#")
 
         # test unknown config file args
         self.assertParseArgsRaises("bla",


### PR DESCRIPTION
Fix the parsing regex to allow whitespace within values when the key and
value are only separated by whitespace.