### PR TITLE
Accept # and ; as values

### DIFF
--- a/configargparse.py
+++ b/configargparse.py
@@ -152,7 +152,7 @@ class DefaultConfigFileParser(ConfigFileParser):
                 continue
             white_space = "\\s*"
             key = "(?P<key>[^:=;#\s]+?)"
-            value = white_space+"[:=\s]"+white_space+"(?P<value>[^;#]+?)"
+            value = white_space+"[:=\s]"+white_space+"(?P<value>.+?)"
             comment = white_space+"(?P<comment>\\s[;#].*)?"
 
             key_only_match = re.match("^" + key + comment + "$", line)

--- a/tests/test_configargparse.py
+++ b/tests/test_configargparse.py
@@ -441,8 +441,6 @@ class TestBasicUseCases(TestCase):
                                    "the following arguments are required: --y",
                                    args="-x 5",
                                    config_file_contents="z: 1")
-        self.assertParseArgsRaises("Unexpected line 0",
-                                   config_file_contents="z z#")
 
         # test unknown config file args
         self.assertParseArgsRaises("bla",


### PR DESCRIPTION
https://github.com/bw2/ConfigArgParse/issues/60

Unless there's some side effect that I'm missing, the only test that failed here was the:

`        self.assertParseArgsRaises("Unexpected line 0",
                                   config_file_contents="z z#")`

that tests for a comment delimiter in there. 
With this change value for key z becomes z#