### PR TITLE
Small fix for print_help() when default_config_files is a non-list sequence

### DIFF
--- a/configargparse.py
+++ b/configargparse.py
@@ -815,8 +815,8 @@ class ArgumentParser(argparse.ArgumentParser):
                 if config_arg_string:
                     config_arg_string = "specified via " + config_arg_string
                 if default_config_files or config_arg_string:
-                    msg += " (%s)." % " or ".join(default_config_files +
-                                                  list(filter(None, [config_arg_string])))
+                    msg += " (%s)." % " or ".join(tuple(default_config_files) +
+                                                  tuple(filter(None, [config_arg_string])))
                 msg += " " + self._config_file_parser.get_syntax_description()
 
         if self._add_env_var_help:


### PR DESCRIPTION
I ran into the following issue:

When I create a configargparser with Parser(default_config_files=(some, tuple, of strs)), parser.print_help() fails, because it tries to append default_config_files to a list object, and directly merging tuples and lists doesn't work.

This is a simple fix to coerce both sequences into a tuple (chosen as the most lightweight and type) within print_help() before trying to merge them.  Seems to fix the issue with minimal invasiveness.
