### PR TITLE
Prevent writing args_for_writing_out_config_file to file

### DIFF
--- a/configargparse.py
+++ b/configargparse.py
@@ -317,8 +317,8 @@ class ArgumentParser(argparse.ArgumentParser):
                 be parsed in order, with the values from each config file
                 taking precedence over pervious ones. This allows an application
                 to look for config files in multiple standard locations such as
-                the install directory, home directory, and current directory. 
-                Also, shell * syntax can be used to specify all conf files in a 
+                the install directory, home directory, and current directory.
+                Also, shell * syntax can be used to specify all conf files in a
                 directory. For exmaple:
                 ["/etc/conf/app_config.ini",
                  "/etc/conf/conf-enabled/*.ini",
@@ -696,6 +696,11 @@ class ArgumentParser(argparse.ArgumentParser):
         can be used to set the given action's value in a config file.
         """
         keys = []
+
+        # Do not write out the config options for writing out a config file
+        if getattr(action, 'is_write_out_config_file_arg', None):
+            return keys
+
         for arg in action.option_strings:
             if any([arg.startswith(2*c) for c in self.prefix_chars]):
                 keys += [arg[2:], arg] # eg. for '--bla' return ['bla', '--bla']
@@ -713,7 +718,7 @@ class ArgumentParser(argparse.ArgumentParser):
             command_line_args: List of all args (already split on spaces)
         """
         # open any default config files
-        config_files = [open(f) for files in map(glob.glob, map(os.path.expanduser, self._default_config_files)) 
+        config_files = [open(f) for files in map(glob.glob, map(os.path.expanduser, self._default_config_files))
                         for f in files]
 
         # list actions with is_config_file_arg=True. Its possible there is more

--- a/tests/test_configargparse.py
+++ b/tests/test_configargparse.py
@@ -724,6 +724,49 @@ class TestMisc(TestCase):
         self.assertRaisesRegex(ValueError, "Couldn't open / for writing:",
                                 self.parse, args = command_line_args + " -w /")
 
+    def testConstructor_WriteOutConfigFileArgsLong(self):
+        """Test config writing with long version of arg
+
+        There was a bug where the long version of the
+        args_for_writing_out_config_file was being dumped into the resultant
+        output config file
+        """
+        # Test constructor args:
+        #   args_for_writing_out_config_file
+        #   write_out_config_file_arg_help_message
+        cfg_f = tempfile.NamedTemporaryFile(mode="w+", delete=True)
+        self.initParser(args_for_writing_out_config_file=["--write-config"],
+                        write_out_config_file_arg_help_message="write config")
+
+
+        self.add_arg("-not-config-file-settable")
+        self.add_arg("--config-file-settable-arg", type=int)
+        self.add_arg("--config-file-settable-arg2", type=int, default=3)
+        self.add_arg("--config-file-settable-flag", action="store_true")
+        self.add_arg("-l", "--config-file-settable-list", action="append")
+
+        # write out a config file
+        command_line_args = "--write-config %s " % cfg_f.name
+        command_line_args += "--config-file-settable-arg 1 "
+        command_line_args += "--config-file-settable-flag "
+        command_line_args += "-l a -l b -l c -l d "
+
+        self.assertFalse(self.parser._exit_method_called)
+
+        ns = self.parse(command_line_args)
+        self.assertTrue(self.parser._exit_method_called)
+
+        cfg_f.seek(0)
+        expected_config_file_contents = "config-file-settable-arg = 1\n"
+        expected_config_file_contents += "config-file-settable-flag = true\n"
+        expected_config_file_contents += "config-file-settable-list = [a, b, c, d]\n"
+        expected_config_file_contents += "config-file-settable-arg2 = 3\n"
+
+        self.assertEqual(cfg_f.read().strip(),
+            expected_config_file_contents.strip())
+        self.assertRaisesRegex(ValueError, "Couldn't open / for writing:",
+            self.parse, args = command_line_args + " --write-config /")
+
     def testMethodAliases(self):
         p = self.parser
         p.add("-a", "--arg-a", default=3)


### PR DESCRIPTION
When a long version of the args_for_writing_out_config_file was present, the flag
and a value of True would be written to the resultant config file.  This
prevents those arguments from being populated into the config file.

example:

> my_script.py --write-config ~/.my_config --taco=bell

Contents of ~/.my_config
> write-config = True
> taco = bell

I made these changes without discussing if they are correct or not, so please don't hesitate to criticize as needed. 