### PR TITLE
Fix config file args incorrectly matching to command line args

### DIFF
--- a/configargparse.py
+++ b/configargparse.py
@@ -317,8 +317,8 @@ class ArgumentParser(argparse.ArgumentParser):
                 be parsed in order, with the values from each config file
                 taking precedence over pervious ones. This allows an application
                 to look for config files in multiple standard locations such as
-                the install directory, home directory, and current directory. 
-                Also, shell * syntax can be used to specify all conf files in a 
+                the install directory, home directory, and current directory.
+                Also, shell * syntax can be used to specify all conf files in a
                 directory. For exmaple:
                 ["/etc/conf/app_config.ini",
                  "/etc/conf/conf-enabled/*.ini",
@@ -517,7 +517,7 @@ class ArgumentParser(argparse.ArgumentParser):
                     discard_this_key = self._ignore_unknown_config_file_keys or \
                         already_on_command_line(
                             args,
-                            self.get_command_line_key_for_unknown_config_file_setting(key))
+                            [self.get_command_line_key_for_unknown_config_file_setting(key)])
 
                 if not discard_this_key:
                     config_args += self.convert_item_to_command_line_arg(
@@ -713,7 +713,7 @@ class ArgumentParser(argparse.ArgumentParser):
             command_line_args: List of all args (already split on spaces)
         """
         # open any default config files
-        config_files = [open(f) for files in map(glob.glob, map(os.path.expanduser, self._default_config_files)) 
+        config_files = [open(f) for files in map(glob.glob, map(os.path.expanduser, self._default_config_files))
                         for f in files]
 
         # list actions with is_config_file_arg=True. Its possible there is more

--- a/tests/test_configargparse.py
+++ b/tests/test_configargparse.py
@@ -612,6 +612,27 @@ class TestMisc(TestCase):
         ns, args = self.parse_known(config_file_contents="arg1 = 3")
         self.assertEqual(getattr(ns, "arg1", ""), "")
 
+    def test_AbbrevConfigFileArgs(self):
+        """Tests that abbreviated values don't get pulled from config file.
+
+        """
+        temp_cfg = tempfile.NamedTemporaryFile(mode="w", delete=True)
+        temp_cfg.write("a2a = 0.5\n")
+        temp_cfg.write("a3a = 0.5\n")
+        temp_cfg.flush()
+
+        self.initParser()
+
+        self.add_arg('-c', '--config_file', required=False, is_config_file=True,
+                     help='config file path')
+
+        self.add_arg('--hello', type=int, required=False)
+
+        command = '-c {} --hello 2'.format(temp_cfg.name)
+
+        known, unknown = self.parse_known(command)
+
+        self.assertListEqual(unknown, ['--a2a', '0.5', '--a3a', '0.5'])
 
     def test_FormatHelp(self):
         self.initParser(args_for_setting_config_path=["-c", "--config"],

--- a/tests/test_configargparse.py
+++ b/tests/test_configargparse.py
@@ -628,7 +628,7 @@ class TestMisc(TestCase):
 
         self.add_arg('--hello', type=int, required=False)
 
-        command = '-c {} --hello 2'.format(temp_cfg.name)
+        command = '-c {0} --hello 2'.format(temp_cfg.name)
 
         known, unknown = self.parse_known(command)
 


### PR DESCRIPTION
Config file args were being incorrectly passed as strings in one of the
checks and if a character of the string happened to match a single
character of the command line the config arg would be ignored

fixes #76