### PR TITLE
Convert env-var string-lists to actual python-lists.

### DIFF
--- a/configargparse.py
+++ b/configargparse.py
@@ -464,7 +464,10 @@ class ArgumentParser(argparse.ArgumentParser):
                 and not already_on_command_line(args, a.option_strings)]
         for action in actions_with_env_var_values:
             key = action.env_var
-            value = env_vars[key]  # TODO parse env var values here to allow lists?
+            value = env_vars[key]
+            # Make list-string into list.
+            element_capture = re.match('\[(.*)\]', value)
+            value = [val.strip() for val in element_capture.group(1).split(',')] if element_capture else value
             env_var_args += self.convert_item_to_command_line_arg(
                 action, key, value)
 
@@ -659,10 +662,6 @@ class ArgumentParser(argparse.ArgumentParser):
             value: parsed value of type string or list
         """
         args = []
-
-        # Make list-string into list.
-        element_capture = re.match('\[(.*)\]', value)
-        value = [val.strip() for val in element_capture.group(1).split(',')] if element_capture else value
 
         if action is None:
             command_line_key = \

--- a/configargparse.py
+++ b/configargparse.py
@@ -659,6 +659,11 @@ class ArgumentParser(argparse.ArgumentParser):
             value: parsed value of type string or list
         """
         args = []
+
+        # Make list-string into list.
+        element_capture = re.match('\[(.*)\]', value)
+        value = [val.strip() for val in element_capture.group(1).split(',')] if element_capture is not None else value
+
         if action is None:
             command_line_key = \
                 self.get_command_line_key_for_unknown_config_file_setting(key)

--- a/configargparse.py
+++ b/configargparse.py
@@ -662,7 +662,7 @@ class ArgumentParser(argparse.ArgumentParser):
 
         # Make list-string into list.
         element_capture = re.match('\[(.*)\]', value)
-        value = [val.strip() for val in element_capture.group(1).split(',')] if element_capture is not None else value
+        value = [val.strip() for val in element_capture.group(1).split(',')] if element_capture else value
 
         if action is None:
             command_line_key = \

--- a/configargparse.py
+++ b/configargparse.py
@@ -467,7 +467,8 @@ class ArgumentParser(argparse.ArgumentParser):
             value = env_vars[key]
             # Make list-string into list.
             element_capture = re.match('\[(.*)\]', value)
-            value = [val.strip() for val in element_capture.group(1).split(',')] if element_capture else value
+            if element_capture:
+                value = [val.strip() for val in element_capture.group(1).split(',') if val.strip()]
             env_var_args += self.convert_item_to_command_line_arg(
                 action, key, value)
 

--- a/tests/test_configargparse.py
+++ b/tests/test_configargparse.py
@@ -520,6 +520,21 @@ class TestBasicUseCases(TestCase):
         self.assertEqual(ns.arg4, "arg4_value")
         self.assertEqual(ns.arg4_more, "magic")
 
+    def testEnvVarLists(self):
+        self.initParser()
+        self.add_arg("-x", "--arg2", env_var="TEST2")
+        self.add_arg("-y", "--arg3", env_var="TEST3", type=int)
+        self.add_arg("-z", "--arg4", env_var="TEST4", nargs="+")
+        self.add_arg("-u", "--arg5", env_var="TEST5", nargs="+", type=int)
+        ns = self.parse("", env_vars={"TEST2": "22",
+                                      "TEST3": "22",
+                                      "TEST4": "[Shell, someword, anotherword]",
+                                      "TEST5": "[22, 99, 33]"})
+        self.assertEqual(ns.arg2, "22")
+        self.assertEqual(ns.arg3, 22)
+        self.assertEqual(ns.arg4, ['Shell', 'someword', 'anotherword'])
+        self.assertEqual(ns.arg5, [22, 99, 33])
+
 class TestMisc(TestCase):
     # TODO test different action types with config file, env var
 


### PR DESCRIPTION
Allows for list input from environment-variables if correctly configured.
Previously always detected input as string-type