### PR TITLE
Handle empty config_file_contents

### DIFF
--- a/configargparse.py
+++ b/configargparse.py
@@ -492,7 +492,7 @@ class ArgumentParser(argparse.ArgumentParser):
 
         # open the config file(s)
         config_streams = []
-        if config_file_contents:
+        if config_file_contents is not None:
             stream = StringIO(config_file_contents)
             stream.name = "method arg"
             config_streams = [stream]


### PR DESCRIPTION
To suppress loading configuration files, passing `config_file_contents=''` seems like the natural solution. However, this does not what is expected. This changes this.