### PR TITLE
All kwargs that are irrelevant to ConfigArgParse are blindly pushed to argparse

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ python:
   - "pypy"
 
 # command to install dependencies: 
-# install: pip install -r requirements.txt
+install: pip install mock
 
 # command to run tests: 
 script: python setup.py test

--- a/configargparse.py
+++ b/configargparse.py
@@ -266,41 +266,24 @@ class ArgumentParser(argparse.ArgumentParser):
     """
 
     def __init__(self,
-        prog=None,
-        usage=None,
-        description=None,
-        epilog=None,
-        version=None,
-        parents=[],
-        formatter_class=argparse.HelpFormatter,
-        prefix_chars='-',
-        fromfile_prefix_chars=None,
-        argument_default=None,
-        conflict_handler='error',
-        add_help=True,
-
         add_config_file_help=True,
         add_env_var_help=True,
-
         auto_env_var_prefix=None,
-
         default_config_files=[],
         ignore_unknown_config_file_keys=False,
         config_file_parser_class=DefaultConfigFileParser,
-
         args_for_setting_config_path=[],
         config_arg_is_required=False,
         config_arg_help_message="config file path",
-
         args_for_writing_out_config_file=[],
         write_out_config_file_arg_help_message="takes the current command line "
             "args and writes them out to a config file at the given path, then "
             "exits",
-        allow_abbrev=True,  # new in python 3.5
+        **kwargs
         ):
 
-        """Supports all the same args as the argparse.ArgumentParser
-        constructor, as well as the following additional args.
+        """Supports args of the argparse.ArgumentParser constructor
+        as **kwargs, as well as the following additional args.
 
         Additional Args:
             add_config_file_help: Whether to add a description of config file
@@ -347,24 +330,12 @@ class ArgumentParser(argparse.ArgumentParser):
                 (eg. ["-w", "--write-out-config-file"]). Default: []
             write_out_config_file_arg_help_message: The help message to use for
                 the args in args_for_writing_out_config_file.
-            allow_abbrev: Allows long options to be abbreviated if the
-                abbreviation is unambiguous. Default: True
         """
         self._add_config_file_help = add_config_file_help
         self._add_env_var_help = add_env_var_help
         self._auto_env_var_prefix = auto_env_var_prefix
 
-        # extract kwargs that can be passed to the super constructor
-        kwargs_for_super = dict((k, v) for k, v in locals().items() if k in [
-            "prog", "usage", "description", "epilog", "version", "parents",
-            "formatter_class", "prefix_chars", "fromfile_prefix_chars",
-            "argument_default", "conflict_handler", "add_help"])
-        if sys.version_info >= (3, 3) and "version" in kwargs_for_super:
-            del kwargs_for_super["version"]  # version arg deprecated in v3.3
-        if sys.version_info >= (3, 5):
-            kwargs_for_super["allow_abbrev"] = allow_abbrev  # new option in v3.5
-
-        argparse.ArgumentParser.__init__(self, **kwargs_for_super)
+        argparse.ArgumentParser.__init__(self, **kwargs)
 
         # parse the additionial args
         if config_file_parser_class is None:

--- a/configargparse.py
+++ b/configargparse.py
@@ -337,7 +337,7 @@ class ArgumentParser(argparse.ArgumentParser):
 
         argparse.ArgumentParser.__init__(self, **kwargs)
 
-        # parse the additionial args
+        # parse the additional args
         if config_file_parser_class is None:
             self._config_file_parser = DefaultConfigFileParser()
         else:

--- a/tests/test_configargparse.py
+++ b/tests/test_configargparse.py
@@ -1,11 +1,15 @@
 import argparse
 import configargparse
-import functools
 import inspect
 import logging
 import sys
 import tempfile
 import types
+
+try:
+    import mock
+except ImportError:
+    from unittest import mock
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -601,6 +605,14 @@ class TestMisc(TestCase):
     """Test edge cases"""
     def setUp(self):
         self.initParser(args_for_setting_config_path=[])
+
+    @mock.patch('argparse.ArgumentParser.__init__')
+    def testKwrgsArePassedToArgParse(self, argparse_init):
+        kwargs_for_argparse = {"allow_abbrev": False, "whatever_other_arg": "something"}
+
+        parser = configargparse.ArgumentParser(add_config_file_help=False, **kwargs_for_argparse)
+
+        argparse_init.assert_called_with(parser, **kwargs_for_argparse)
 
     def testGlobalInstances(self, name=None):
         p = configargparse.getArgumentParser(name, prog="prog", usage="test")


### PR DESCRIPTION
Fixes #73 and #77.