### PR TITLE
Fix to remove env variable handler on argparse.VersionAction

### DIFF
--- a/configargparse.py
+++ b/configargparse.py
@@ -422,6 +422,7 @@ class ArgumentParser(argparse.ArgumentParser):
                 config_file_keys = self.get_possible_config_keys(a)
                 if config_file_keys and not (a.env_var or a.is_positional_arg
                     or a.is_config_file_arg or a.is_write_out_config_file_arg or
+                    isinstance(a, argparse._VersionAction) or
                     isinstance(a, argparse._HelpAction)):
                     stripped_config_file_key = config_file_keys[0].strip(
                         self.prefix_chars)


### PR DESCRIPTION
Hi,
When I use a a version action like so : 

```python
    misc_group = parser.add_argument_group('Miscellaneous commands')
    misc_group.add_argument("-h", "--help", action="help", help="show this help message and exit")
    misc_group.add_argument('--version', action='version', version='%(prog)s {version}'.format(version=get_version()), env_var=None)
```
It displays the following : 
```
    Miscellaneous commands:
      -h, --help            show this help message and exit
      --version             show program's version number and exit [env var:
                            PREFIX.VERSION]
```
The env var PREFIX.VERSION for the `--version` action should not be displayed as it is an action with same behavior as `--help`. This PR should fix it.
And by the way, thanks for this awesome piece of work that will save me a lot of time. 
Cheers!