### PR TITLE
Handle unicode with .encode('utf-8')

### DIFF
--- a/configargparse.py
+++ b/configargparse.py
@@ -231,6 +231,8 @@ class YAMLConfigFileParser(ConfigFileParser):
         for key, value in parsed_obj.items():
             if isinstance(value, list):
                 result[key] = value
+            elif isinstance(value, unicode):
+                result[key] = value.encode('utf-8')
             else:
                 result[key] = str(value)
 


### PR DESCRIPTION
str(_) on a unicode object fails, so instead we use .encode('utf-8').

An example YML file which fails for me is one containing only 
```YML
name: "Åshild"
```
It fails with  
`UnicodeEncodeError: 'ascii' codec can't encode character u'\xc5' in position 0: ordinal not in range(128)` at `result[key] = str(value)`c

