### PR TITLE
Fix unittests on Python 3.6.

### DIFF
--- a/tests/test_configargparse.py
+++ b/tests/test_configargparse.py
@@ -233,8 +233,8 @@ class TestBasicUseCases(TestCase):
 
         if not use_groups:
             self.assertRegex(self.format_help(),
-                'usage: .* \[-h\] --genome GENOME \[-v\] -g MY_CFG_FILE'
-                ' \[-d DBSNP\]\s+\[-f FRMT\]\s+vcf \[vcf ...\]\n\n' +
+                'usage: .* \[-h\] --genome GENOME \[-v\] -g MY_CFG_FILE\n?'
+                '\s+\[-d DBSNP\]\s+\[-f FRMT\]\s+vcf \[vcf ...\]\n\n' +
                 9*'(.+\s+)'+  # repeated 8 times because .+ matches atmost 1 line
                 'positional arguments:\n'
                 '  vcf \s+ Variant file\(s\)\n\n'
@@ -247,8 +247,8 @@ class TestBasicUseCases(TestCase):
                 '  -f FRMT, --format FRMT\s+\[env var: OUTPUT_FORMAT\]\n')
         else:
             self.assertRegex(self.format_help(),
-                'usage: .* \[-h\] --genome GENOME \[-v\] -g MY_CFG_FILE'
-                ' \[-d DBSNP\]\s+\[-f FRMT\]\s+vcf \[vcf ...\]\n\n'+
+                'usage: .* \[-h\] --genome GENOME \[-v\] -g MY_CFG_FILE\n?'
+                '\s+\[-d DBSNP\]\s+\[-f FRMT\]\s+vcf \[vcf ...\]\n\n'+
                 9*'.+\s+'+  # repeated 8 times because .+ matches atmost 1 line
                 'positional arguments:\n'
                 '  vcf \s+ Variant file\(s\)\n\n'


### PR DESCRIPTION
Running the unit tests on Mac OSX with Python 3.6.1 gives me two unit test failures:

```
======================================================================
FAIL: testBasicCase2 (__main__.TestBasicUseCases)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_configargparse.py", line 239, in testBasicCase2
    'positional arguments:\n'
AssertionError: Regex didn't match: 'usage: .* \\[-h\\] --genome GENOME \\[-v\\] -g MY_CFG_FILE \\[-d DBSNP\\]\\s+\\[-f FRMT\\]\\s+vcf \\[vcf ...\\]\n\n(.+\\s+)(.+\\s+)(.+\\s+)(.+\\s+)(.+\\s+)(.+\\s+)(.+\\s+)(.+\\s+)(.+\\s+)positional arguments:\n  vcf \\s+ Variant file\\(s\\)\n\noptional arguments:\n  -h, --help \\s+ show this help message and exit\n  --genome GENOME \\s+ Path to genome file\n  -v\n  -g MY_CFG_FILE, --my-cfg-file MY_CFG_FILE\n  -d DBSNP, --dbsnp DBSNP\\s+\\[env var: DBSNP_PATH\\]\n  -f FRMT, --format FRMT\\s+\\[env var: OUTPUT_FORMAT\\]\n' not found in "usage: test_configargparse.py [-h] --genome GENOME [-v] -g MY_CFG_FILE\n                              [-d DBSNP] [-f FRMT]\n                              vcf [vcf ...]\n\nArgs that start with '--' (eg. --genome) can also be set in a config file\n(/etc/settings.ini or /home/jeff/.user_settings or\n/var/folders/sg/dhmz_8gd1g52c5s226lvrzlm0000gn/T/tmp47hj1yr4 or specified via\n-g). Config file syntax allows: key=value, flag=true, stuff=[a,b,c] (for\ndetails, see syntax at https://goo.gl/R74nmi). If an arg is specified in more\nthan one place, then commandline values override environment variables which\noverride config file values which override defaults.\n\npositional arguments:\n  vcf                   Variant file(s)\n\noptional arguments:\n  -h, --help            show this help message and exit\n  --genome GENOME       Path to genome file\n  -v\n  -g MY_CFG_FILE, --my-cfg-file MY_CFG_FILE\n  -d DBSNP, --dbsnp DBSNP\n                        [env var: DBSNP_PATH]\n  -f FRMT, --format FRMT\n                        [env var: OUTPUT_FORMAT]\n"

======================================================================
FAIL: testBasicCase2_WithGroups (__main__.TestBasicUseCases)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_configargparse.py", line 275, in testBasicCase2_WithGroups
    self.testBasicCase2(use_groups=True)
  File "test_configargparse.py", line 253, in testBasicCase2
    'positional arguments:\n'
AssertionError: Regex didn't match: 'usage: .* \\[-h\\] --genome GENOME \\[-v\\] -g MY_CFG_FILE \\[-d DBSNP\\]\\s+\\[-f FRMT\\]\\s+vcf \\[vcf ...\\]\n\n.+\\s+.+\\s+.+\\s+.+\\s+.+\\s+.+\\s+.+\\s+.+\\s+.+\\s+positional arguments:\n  vcf \\s+ Variant file\\(s\\)\n\noptional arguments:\n  -h, --help \\s+ show this help message and exit\n\ng1:\n  --genome GENOME \\s+ Path to genome file\n  -v\n  -g MY_CFG_FILE, --my-cfg-file MY_CFG_FILE\n\ng2:\n  -d DBSNP, --dbsnp DBSNP\\s+\\[env var: DBSNP_PATH\\]\n  -f FRMT, --format FRMT\\s+\\[env var: OUTPUT_FORMAT\\]\n' not found in "usage: test_configargparse.py [-h] --genome GENOME [-v] -g MY_CFG_FILE\n                              [-d DBSNP] [-f FRMT]\n                              vcf [vcf ...]\n\nArgs that start with '--' (eg. --genome) can also be set in a config file\n(/etc/settings.ini or /home/jeff/.user_settings or\n/var/folders/sg/dhmz_8gd1g52c5s226lvrzlm0000gn/T/tmpdz6lqbto or specified via\n-g). Config file syntax allows: key=value, flag=true, stuff=[a,b,c] (for\ndetails, see syntax at https://goo.gl/R74nmi). If an arg is specified in more\nthan one place, then commandline values override environment variables which\noverride config file values which override defaults.\n\npositional arguments:\n  vcf                   Variant file(s)\n\noptional arguments:\n  -h, --help            show this help message and exit\n\ng1:\n  --genome GENOME       Path to genome file\n  -v\n  -g MY_CFG_FILE, --my-cfg-file MY_CFG_FILE\n\ng2:\n  -d DBSNP, --dbsnp DBSNP\n                        [env var: DBSNP_PATH]\n  -f FRMT, --format FRMT\n                        [env var: OUTPUT_FORMAT]\n"
```

Apparently, a line break and indentation is inserted after `-g MY_CFG_FILE` that the regex isn't prepared for. The fix adds an optional line break and optional indentation so that if the unit tests did work on another platform they should keep working.
