### PR TITLE
Switch to search for config files in default (appdirs) locations

### DIFF
--- a/configargparse.py
+++ b/configargparse.py
@@ -1,3 +1,7 @@
+# NB: This is a MODIFIED COPY of configargparse, adding the appdir_conf argument.
+# https://pypi.org/project/ConfigArgParse/
+# A pull request has been submitted.
+
 import argparse
 import glob
 import os
@@ -154,8 +158,8 @@ class DefaultConfigFileParser(ConfigFileParser):
             if not line or line[0] in ["#", ";", "["] or line.startswith("---"):
                 continue
             white_space = "\\s*"
-            key = "(?P<key>[^:=;#\s]+?)"
-            value = white_space+"[:=\s]"+white_space+"(?P<value>.+?)"
+            key = r"(?P<key>[^:=;#\s]+?)"
+            value = white_space+r"[:=\s]"+white_space+"(?P<value>.+?)"
             comment = white_space+"(?P<comment>\\s[;#].*)?"
 
             key_only_match = re.match("^" + key + comment + "$", line)
@@ -364,8 +368,8 @@ class ArgumentParser(argparse.ArgumentParser):
 
             appdir = appdirs.AppDirs(appname=appdir_name)
             default_config_files.extend( [
-                 pathlib.Path(appdir.site_config_dir,appdir_name+'.conf')
-                ,pathlib.Path(appdir.user_config_dir,appdir_name+'.conf')]
+                 str(pathlib.Path(appdir.site_config_dir,appdir_name+'.conf'))
+                ,str(pathlib.Path(appdir.user_config_dir,appdir_name+'.conf'))]
             )
 
         self._ignore_unknown_config_file_keys = ignore_unknown_config_file_keys
@@ -463,7 +467,7 @@ class ArgumentParser(argparse.ArgumentParser):
             value = env_vars[key]
             # Make list-string into list.
             if action.nargs or isinstance(action, argparse._AppendAction):
-                element_capture = re.match('\[(.*)\]', value)
+                element_capture = re.match(r'\[(.*)\]', value)
                 if element_capture:
                     value = [val.strip() for val in element_capture.group(1).split(',') if val.strip()]
             env_var_args += self.convert_item_to_command_line_arg(


### PR DESCRIPTION
For cross-platform apps, config file locations should always be specified using appdirs.  This allows it to be used with a single flag.