### PR TITLE
Prepend environment variables and config values for subparser support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ docs/_build
 
 # IDEs
 .idea
+
+.eggs/

--- a/configargparse.py
+++ b/configargparse.py
@@ -445,7 +445,7 @@ class ArgumentParser(argparse.ArgumentParser):
             env_var_args += self.convert_item_to_command_line_arg(
                 action, key, value)
 
-        args = args + env_var_args
+        args = env_var_args + args
 
         if env_var_args:
             self._source_to_settings[_ENV_VAR_SOURCE_KEY] = OrderedDict(
@@ -504,7 +504,7 @@ class ArgumentParser(argparse.ArgumentParser):
                         self._source_to_settings[source_key] = OrderedDict()
                     self._source_to_settings[source_key][key] = (action, value)
 
-            args = args + config_args
+            args = config_args + args
 
 
         # save default settings for use by print_values()


### PR DESCRIPTION
When you have a subparser or subcommand configured, the environment variable and config file support breaks the *argparse* parsing of the arguments.

`['--opt', 'subcommand', '--config-opt']` must be like `['--opt', '--config-opt', 'subcommand']` if `--config-opt` is set at the top level parser, or it throws an error. 

Switching the order of the env-var and config-file parsed arguments to be prepended fixes this issue. It should not cause any other issues, since positional vars are not able to bet set through environment or config files.