### PR TITLE
Separate the runtime config saver so that a custom saver can be used

### DIFF
--- a/configargparse.py
+++ b/configargparse.py
@@ -253,9 +253,11 @@ class YAMLConfigFileParser(ConfigFileParser):
 
 class ConfigSaver(object):
     """This abstract class can be extended to add support for new config saver to save the valid runtime config.
-    it saves the config in the format returned by ConfigFileParser.serialize"""
+    the idea is to be able to save to a file, database or distributed filesystem .
+    it saves the config in the format returned by ConfigFileParser.serialize
+    """
 
-    def save(self, config_content):
+    def save(self, config_content, output_file_path):
         """writes the content of the runtime config. Otherwise an error will be raised.
 
         Args:

--- a/tests/test_configargparse.py
+++ b/tests/test_configargparse.py
@@ -1027,11 +1027,6 @@ class TestConfigFileParsers(TestCase):
             ('list_arg', [1,2,3]),
         ]))
 
-class TestConfigSaver(TestCase):
-    """Test ConfigFileParser subclasses in isolation"""
-
-    def testDefaultConfigSaver_Basic(self):
-        pass
 
 
 ################################################################################

--- a/tests/test_configargparse.py
+++ b/tests/test_configargparse.py
@@ -1027,6 +1027,11 @@ class TestConfigFileParsers(TestCase):
             ('list_arg', [1,2,3]),
         ]))
 
+class TestConfigSaver(TestCase):
+    """Test ConfigFileParser subclasses in isolation"""
+
+    def testDefaultConfigSaver_Basic(self):
+        pass
 
 
 ################################################################################


### PR DESCRIPTION
The idea is to be able to save runtime config to a location other than a file. In my case I needed to save it to s3.