### PR TITLE
Fix parsing of args entries like "--key=-value"

### DIFF
--- a/tests/test_configargparse.py
+++ b/tests/test_configargparse.py
@@ -595,6 +595,13 @@ class TestBasicUseCases(TestCase):
         self.assertEqual(ns.arg, ['Shell', 'someword', 'anotherword'])
         self.assertEqual(ns.a, "positional_value")
 
+    def testValuesWithLeadingDash(self):
+        self.initParser()
+        self.add_arg("--key")
+        ns = self.parse("--key=-value")
+        self.assertEqual(ns.key, '-value')
+
+
 class TestMisc(TestCase):
     # TODO test different action types with config file, env var
 


### PR DESCRIPTION
Fixes #154.

You can check the proper behavior of ConfigArgParse with this script:
```
import configargparse
parser = configargparse.ArgumentParser()
parser.add_argument('--my-flag')
print(parser.parse_args(['--my-flag', 'my-value']))
print(parser.parse_args(['--my-flag=my-value']))
print(parser.parse_args(['--my-flag=-my-value']))
```