### PR TITLE
Set COLUMNS=80 in tests to fix failures

### DIFF
--- a/tests/test_configargparse.py
+++ b/tests/test_configargparse.py
@@ -3,6 +3,7 @@ import configargparse
 from contextlib import contextmanager
 import inspect
 import logging
+import os
 import sys
 import tempfile
 import types
@@ -17,6 +18,9 @@ if sys.version_info >= (3, 0):
     from io import StringIO
 else:
     from StringIO import StringIO
+
+# set COLUMNS to get expected wrapping
+os.environ['COLUMNS'] = '80'
 
 # enable logging to simplify debugging
 logger = logging.getLogger()


### PR DESCRIPTION
The tests rely on specific wrapping of text, so set COLUMNS to enforce
it reliably.

The alternatively would be to make tests accept any wrapping, i.e. any
amounts of whitespace between words and therefore would be more work
for no apparent benefit.

Fixes #146, #163