### PR TITLE
Fix help output of suppressed args

### DIFF
--- a/configargparse.py
+++ b/configargparse.py
@@ -827,6 +827,8 @@ class ArgumentParser(argparse.ArgumentParser):
             env_var_actions = [(a.env_var, a) for a in self._actions
                                if getattr(a, "env_var", None)]
             for env_var, a in env_var_actions:
+                if a.help == SUPPRESS:
+                    continue
                 env_var_help_string = "   [env var: %s]" % env_var
                 if not a.help:
                     a.help = ""


### PR DESCRIPTION
Fix help output for suppressed args.
Example:
```
parser.add(
	"--debug",
	env_var="DEBUG",
	action='store_true',
	help=SUPPRESS
)
```
Help output without fix:
```
 --debug                     ==SUPPRESS== [env var: DEBUG]
```