### PR TITLE
Redo fix for nargs and append

### DIFF
--- a/configargparse.py
+++ b/configargparse.py
@@ -741,10 +741,11 @@ class ArgumentParser(argparse.ArgumentParser):
                 self.error("Unexpected value for %s: '%s'. Expecting 'true', "
                            "'false', 'yes', 'no', '1' or '0'" % (key, value))
         elif isinstance(value, list):
-            accepts_list = (isinstance(action, argparse._StoreAction) and 
-                 action.nargs in ('+', '*')) or (
-                 isinstance(action, argparse._StoreAction) and
-                     isinstance(action.nargs, int) and action.nargs > 1)
+            accepts_list = ((isinstance(action, argparse._StoreAction) or
+                             isinstance(action, argparse._AppendAction)) and 
+                            action.nargs is not None and (
+                                action.nargs in ('+', '*')) or 
+                            (isinstance(action.nargs, int) and action.nargs > 1))
 
             if action is None or isinstance(action, argparse._AppendAction):
                 for list_elem in value:


### PR DESCRIPTION
I am stupid and didn't actually fix the behavior for combining append and nargs in #178 

I intended to allow actions of type append to accept lists when used with nargs=+,* or an int > 1 but I forgot to include the check that the action is append. 

I also introduced a bug in #178 by not checking for nargs=None, which I apologize for, and am glad to see it was fixed quickly. This time I handle None correctly. 

