### PR TITLE
Not to use `os.path.isfile`

### DIFF
--- a/configargparse.py
+++ b/configargparse.py
@@ -841,8 +841,10 @@ class ArgumentParser(argparse.ArgumentParser):
             user_config_file = os.path.expanduser(user_config_file)
             try:
                 stream = self._config_file_open_func(user_config_file)
-            except OSError:
-                self.error('File not found: %s' % user_config_file)
+            except Exception as e:
+                self.error("Unable to open config file: %s. Error: %s" % (
+                    user_config_file, e
+                ))
 
             config_files += [stream]
 

--- a/configargparse.py
+++ b/configargparse.py
@@ -842,8 +842,12 @@ class ArgumentParser(argparse.ArgumentParser):
             try:
                 stream = self._config_file_open_func(user_config_file)
             except Exception as e:
+                if len(e.args) == 2:  # OSError
+                    errno, msg = e.args
+                else:
+                    msg = str(e)
                 self.error("Unable to open config file: %s. Error: %s" % (
-                    user_config_file, e
+                    user_config_file, msg
                 ))
 
             config_files += [stream]

--- a/configargparse.py
+++ b/configargparse.py
@@ -841,7 +841,7 @@ class ArgumentParser(argparse.ArgumentParser):
             user_config_file = os.path.expanduser(user_config_file)
             try:
                 stream = self._config_file_open_func(user_config_file)
-            except:
+            except OSError:
                 self.error('File not found: %s' % user_config_file)
 
             config_files += [stream]

--- a/configargparse.py
+++ b/configargparse.py
@@ -193,7 +193,7 @@ class ConfigparserConfigFileParser(ConfigFileParser):
     def get_syntax_description(self):
         msg = """Uses configparser module to parse an INI file which allows multi-line
         values.
-        
+
         Allowed syntax is that for a ConfigParser with the following options:
 
             allow_no_value = False,
@@ -202,7 +202,7 @@ class ConfigparserConfigFileParser(ConfigFileParser):
             empty_lines_in_values = False
 
         See https://docs.python.org/3/library/configparser.html for details.
-        
+
         Note: INI file sections names are still treated as comments.
         """
         return msg
@@ -366,7 +366,7 @@ class ArgumentParser(argparse.ArgumentParser):
                 configargparse args will be ignored. If false, they will be
                 processed and appended to the commandline like other args, and
                 can be retrieved using parse_known_args() instead of parse_args()
-            config_file_open_func: function used to open a config file for reading 
+            config_file_open_func: function used to open a config file for reading
                 or writing. Needs to return a file-like object.
             config_file_parser_class: configargparse.ConfigFileParser subclass
                 which determines the config file format. configargparse comes
@@ -742,9 +742,9 @@ class ArgumentParser(argparse.ArgumentParser):
                            "'false', 'yes', 'no', '1' or '0'" % (key, value))
         elif isinstance(value, list):
             accepts_list = ((isinstance(action, argparse._StoreAction) or
-                             isinstance(action, argparse._AppendAction)) and 
+                             isinstance(action, argparse._AppendAction)) and
                             action.nargs is not None and (
-                                action.nargs in ('+', '*')) or 
+                                action.nargs in ('+', '*')) or
                             (isinstance(action.nargs, int) and action.nargs > 1))
 
             if action is None or isinstance(action, argparse._AppendAction):
@@ -836,12 +836,15 @@ class ArgumentParser(argparse.ArgumentParser):
 
             if not user_config_file:
                 continue
-            # validate the user-provided config file path
+
+            # open user-provided config file
             user_config_file = os.path.expanduser(user_config_file)
-            if not os.path.isfile(user_config_file):
+            try:
+                stream = self._config_file_open_func(user_config_file)
+            except:
                 self.error('File not found: %s' % user_config_file)
 
-            config_files += [self._config_file_open_func(user_config_file)]
+            config_files += [stream]
 
         return config_files
 

--- a/tests/test_configargparse.py
+++ b/tests/test_configargparse.py
@@ -189,7 +189,7 @@ class TestBasicUseCases(TestCase):
                                    if sys.version_info.major < 3 else
                                    "the following arguments are required: vcf, -g/--my-cfg-file",
                                    args="--genome hg19")
-        self.assertParseArgsRaises("not found: file.txt", args="-g file.txt")
+        self.assertParseArgsRaises("Unable to open config file: file.txt. Error: No such file or director", args="-g file.txt")
 
         # check values after setting args on command line
         config_file2 = tempfile.NamedTemporaryFile(mode="w", delete=True)
@@ -838,7 +838,7 @@ class TestMisc(TestCase):
 
         self.assertRegex(self.format_help(),
             r'usage: .* \[-h\] -c CONFIG_FILE\s+'
-            r'\[-w CONFIG_OUTPUT_PATH\]\s* --arg1 ARG1\s*\[--flag\]\s*'
+            r'\[-w CONFIG_OUTPUT_PATH\]\s* --arg1\s+ARG1\s*\[--flag\]\s*'
             'Args that start with \'--\' \\(eg. --arg1\\) can also be set in a '
             r'config file\s*\(~/.myconfig or specified via -c\).\s*'
             r'Config file syntax allows: key=value,\s*flag=true, stuff=\[a,b,c\] '

--- a/tests/test_configargparse.py
+++ b/tests/test_configargparse.py
@@ -1029,6 +1029,20 @@ class TestMisc(TestCase):
         options = p.parse(args=[])
         self.assertDictEqual(vars(options), {})
 
+    def testConfigOpenFuncError(self):
+        # test OSError
+        def error_func(path):
+            raise OSError(9, "some error")
+        self.initParser(config_file_open_func=error_func)
+        self.parser.add_argument('-g', is_config_file=True)
+        self.assertParseArgsRaises("Unable to open config file: file.txt. Error: some error", args="-g file.txt")
+
+        # test other error
+        def error_func(path):
+            raise Exception('custom error')
+        self.initParser(config_file_open_func=error_func)
+        self.parser.add_argument('-g', is_config_file=True)
+        self.assertParseArgsRaises("Unable to open config file: file.txt. Error: custom error", args="-g file.txt")
 
 class TestConfigFileParsers(TestCase):
     """Test ConfigFileParser subclasses in isolation"""


### PR DESCRIPTION
I use the [smart-open](https://github.com/RaRe-Technologies/smart_open) as the `config_file_open_func` to open the config from S3, but `os.path.isfile` would block this operation.

As the config file would be opened in `_open_config_files`, we could actually know if there's any error.
Therefore it removes `os.path.isfile` and use try catch to wrap the opener function for this scenario.

