### PR TITLE
fix null to str(None) with YAMLConfigFileParser (issue#198)

### DIFF
--- a/configargparse.py
+++ b/configargparse.py
@@ -300,6 +300,8 @@ class YAMLConfigFileParser(ConfigFileParser):
         for key, value in parsed_obj.items():
             if isinstance(value, list):
                 result[key] = value
+            elif value is None:
+                pass
             else:
                 result[key] = str(value)
 


### PR DESCRIPTION
This fixes #198 where null values in a yaml config file were stored as "None" string instead of None.