### PR TITLE
Add support for args with action append and nargs>1

### DIFF
--- a/configargparse.py
+++ b/configargparse.py
@@ -175,12 +175,11 @@ class DefaultConfigFileParser(ConfigFileParser):
                                 value.append([elem.strip() for elem in l_value[1:idx].split(",")])
                                 l_value = l_value[idx+1:].strip()
                             else:
-                                # bad format?  just append the remainder
+                                # bad format? just append the remainder
                                 value.append([l_value])
                                 l_value = ""
                             if l_value.startswith(","):
                                 l_value = l_value[1:].strip()
-                        print("key:", key, "value:", value)
                     else:
                         # handle special case of lists
                         value = [elem.strip() for elem in value[1:-1].split(",")]

--- a/configargparse.py
+++ b/configargparse.py
@@ -164,8 +164,26 @@ class DefaultConfigFileParser(ConfigFileParser):
                 value = key_value_match.group("value")
 
                 if value.startswith("[") and value.endswith("]"):
-                    # handle special case of lists
-                    value = [elem.strip() for elem in value[1:-1].split(",")]
+                    l_value = value[1:-1]
+                    if l_value.startswith("[") and l_value.endswith("]"):
+                        # handle special case of list of lists
+                        # m = [['1', '2', '3'], ['4', '5', '6']]
+                        value = []
+                        while l_value and 0 < len(l_value):
+                            if l_value.startswith("[") and l_value.endswith("]"):
+                                idx = l_value.find("]")
+                                value.append([elem.strip() for elem in l_value[1:idx].split(",")])
+                                l_value = l_value[idx+1:].strip()
+                            else:
+                                # bad format?  just append the remainder
+                                value.append([l_value])
+                                l_value = ""
+                            if l_value.startswith(","):
+                                l_value = l_value[1:].strip()
+                        print("key:", key, "value:", value)
+                    else:
+                        # handle special case of lists
+                        value = [elem.strip() for elem in value[1:-1].split(",")]
 
                 items[key] = value
                 continue

--- a/tests/test_configargparse.py
+++ b/tests/test_configargparse.py
@@ -480,7 +480,7 @@ class TestBasicUseCases(TestCase):
             '  b: \\s+ True\n'
             '  a: \\s+ 33\n'
             '  z: \\s+ z 1\n')
-
+        self.assertEqual(ns.m, [['1','2','3'],['4','5','6']])
 
         # -x is not a long arg so can't be set via config file
         self.assertParseArgsRaises("argument -x is required"

--- a/tests/test_configargparse.py
+++ b/tests/test_configargparse.py
@@ -427,6 +427,7 @@ class TestBasicUseCases(TestCase):
         self.add_arg('--c')
         self.add_arg('--b', action="store_true")
         self.add_arg('--a', action="append", type=int)
+        self.add_arg('--m', action="append", nargs=3, metavar=("<a1>", "<a2>", "<a3>"),)
 
         ns = self.parse(args="-x 1", env_vars={}, config_file_contents="""
 
@@ -462,6 +463,8 @@ class TestBasicUseCases(TestCase):
         a = 33
         ---
         z z 1
+        ---
+        m = [[1, 2, 3], [4, 5, 6]]
         """)
 
         self.assertEqual(ns.x, 1)


### PR DESCRIPTION
For args that are setup as:

add_arg('--m', action="append", nargs=3, metavar=("<a1>", "<a2>", "<a3>"),)

(action append and nargs>1)

... parse the input file as an array of arrays:

m = [[1, 2, 3], [4, 5, 6]]
