### PR TITLE
AddingPowerSupport_CI/Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,12 @@ python:
   - 2.7
   - pypy
   - pypy3
+jobs:
+ exclude:
+  - arch: ppc64le
+    python: pypy
+  - arch: ppc64le
+    python: pypy3
 
 # command to install dependencies: 
 install: pip install mock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 # Config file for automatic testing at travis-ci.org
 
+arch:
+  - amd64
+  - ppc64le
 language: python
 
 python:


### PR DESCRIPTION
Adding power support.

Adding power support ppc64le with Continues Integration/testing so that code remains architecture independent.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.

The build is successful on both arch: amd64/ppc64le, please find the Travis Link below.
https://travis-ci.com/github/santosh653/ConfigArgParse

Please let me know if you need any further details.

Thank You !!