### PR TITLE
Add mock to test requirements.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ if command not in ['test', 'coverage']:
 
 install_requires = []
 tests_require = [
+    'mock',
     'PyYAML',
 ]
 


### PR DESCRIPTION
Fixes error `AttributeError: 'module' object has no attribute 'test_configargparse'`
Credits to @hlieberman for finding the cause.
Fixes #125.