### PR TITLE
Rewrite DefaultConfigFileParser.parse()

### DIFF
--- a/configargparse.py
+++ b/configargparse.py
@@ -149,22 +149,19 @@ class DefaultConfigFileParser(ConfigFileParser):
             line = line.strip()
             if not line or line[0] in ["#", ";", "["] or line.startswith("---"):
                 continue
-            white_space = "\\s*"
-            key = r"(?P<key>[^:=;#\s]+?)"
-            value = white_space+r"[:=\s]"+white_space+"(?P<value>.+?)"
-            comment = white_space+"(?P<comment>\\s[;#].*)?"
 
-            key_only_match = re.match("^" + key + comment + "$", line)
-            if key_only_match:
-                key = key_only_match.group("key")
-                items[key] = "true"
-                continue
-
-            key_value_match = re.match("^"+key+value+comment+"$", line)
-            if key_value_match:
-                key = key_value_match.group("key")
-                value = key_value_match.group("value")
-
+            match = re.match(r'^(?P<key>[\w\-]+)\s*' 
+                             r'(?:(?P<equal>[:=\s])\s*([\'"]?)(?P<value>.+?)?\3)?'
+                             r'\s*(?:\s[;#]\s*(?P<comment>.*?)\s*)?$', line)
+            if match:
+                key = match.group("key")
+                equal = match.group('equal')
+                value = match.group("value")
+                comment = match.group("comment")
+                if value is None and equal is not None and equal != ' ':
+                    value = ''
+                elif value is None:
+                    value = "true"
                 if value.startswith("[") and value.endswith("]"):
                     # handle special case of k=[1,2,3] or other json-like syntax
                     try:
@@ -172,13 +169,12 @@ class DefaultConfigFileParser(ConfigFileParser):
                     except Exception as e:
                         # for backward compatibility with legacy format (eg. where config value is [a, b, c] instead of proper json ["a", "b", "c"]
                         value = [elem.strip() for elem in value[1:-1].split(",")]
-
+                if comment:
+                    comment = comment.strip()[1:].strip()
                 items[key] = value
-                continue
-
-
-            raise ConfigFileParserException("Unexpected line {} in {}: {}".format(i,
-                getattr(stream, 'name', 'stream'), line))
+            else:
+                raise ConfigFileParserException("Unexpected line {} in {}: {}".format(i,
+                    getattr(stream, 'name', 'stream'), line))
         return items
 
     def serialize(self, items):

--- a/configargparse.py
+++ b/configargparse.py
@@ -150,7 +150,7 @@ class DefaultConfigFileParser(ConfigFileParser):
             if not line or line[0] in ["#", ";", "["] or line.startswith("---"):
                 continue
 
-            match = re.match(r'^(?P<key>[\w\-]+)\s*' 
+            match = re.match(r'^(?P<key>[^:=;#\s]+)\s*'
                              r'(?:(?P<equal>[:=\s])\s*([\'"]?)(?P<value>.+?)?\3)?'
                              r'\s*(?:\s[;#]\s*(?P<comment>.*?)\s*)?$', line)
             if match:

--- a/tests/test_configargparse.py
+++ b/tests/test_configargparse.py
@@ -1102,6 +1102,240 @@ class TestConfigFileParsers(TestCase):
         self.assertListEqual(parsed_obj['_list_arg1'], ['a', 'b', 'c'])
         self.assertListEqual(parsed_obj['_list_arg2'], [1, 2, 3])
 
+    def testDefaultConfigFileParser_BasicValues(self):
+        p = configargparse.DefaultConfigFileParser()
+
+        # test the all syntax case
+        config_lines = [
+            {'line': 'key = value # comment # comment',   'expected': ('key', 'value', 'comment # comment')},
+            {'line': 'key=value#comment ',                'expected': ('key', 'value#comment', None)},
+            {'line': 'key=value',                         'expected': ('key', 'value', None)},
+            {'line': 'key =value',                        'expected': ('key', 'value', None)},
+            {'line': 'key= value',                        'expected': ('key', 'value', None)},
+            {'line': 'key = value',                       'expected': ('key', 'value', None)},
+            {'line': 'key  =  value',                     'expected': ('key', 'value', None)},
+            {'line': ' key  =  value ',                   'expected': ('key', 'value', None)},
+            {'line': 'key:value',                         'expected': ('key', 'value', None)},
+            {'line': 'key :value',                        'expected': ('key', 'value', None)},
+            {'line': 'key: value',                        'expected': ('key', 'value', None)},
+            {'line': 'key : value',                       'expected': ('key', 'value', None)},
+            {'line': 'key  :  value',                     'expected': ('key', 'value', None)},
+            {'line': ' key  :  value ',                   'expected': ('key', 'value', None)},
+            {'line': 'key value',                         'expected': ('key', 'value', None)},
+            {'line': 'key  value',                        'expected': ('key', 'value', None)},
+            {'line': ' key    value ',                    'expected': ('key', 'value', None)},
+        ]
+
+        for test in config_lines:
+            parsed_obj = p.parse(StringIO(test['line']))
+            parsed_obj = dict(parsed_obj)
+            expected = {test['expected'][0]: test['expected'][1]}
+            self.assertDictEqual(parsed_obj, expected,
+                    msg="Line %r" % (test['line']))
+
+    def testDefaultConfigFileParser_QuotedValues(self):
+        p = configargparse.DefaultConfigFileParser()
+
+        # test the all syntax case
+        config_lines = [
+            {'line': 'key="value"',                       'expected': ('key', 'value', None)},
+            {'line': 'key  =  "value"',                   'expected': ('key', 'value', None)},
+            {'line': ' key  =  "value" ',                 'expected': ('key', 'value', None)},
+            {'line': 'key=" value "',                     'expected': ('key', ' value ', None)},
+            {'line': 'key  =  " value "',                 'expected': ('key', ' value ', None)},
+            {'line': ' key  =  " value " ',               'expected': ('key', ' value ', None)},
+            {'line': "key='value'",                       'expected': ('key', 'value', None)},
+            {'line': "key  =  'value'",                   'expected': ('key', 'value', None)},
+            {'line': " key  =  'value' ",                 'expected': ('key', 'value', None)},
+            {'line': "key=' value '",                     'expected': ('key', ' value ', None)},
+            {'line': "key  =  ' value '",                 'expected': ('key', ' value ', None)},
+            {'line': " key  =  ' value ' ",               'expected': ('key', ' value ', None)},
+            {'line': 'key="',                             'expected': ('key', '"', None)},
+            {'line': 'key  =  "',                         'expected': ('key', '"', None)},
+            {'line': ' key  =  " ',                       'expected': ('key', '"', None)},
+            {'line': 'key = \'"value"\'',                 'expected': ('key', '"value"', None)},
+            {'line': 'key = "\'value\'"',                 'expected': ('key', "'value'", None)},
+            {'line': 'key = ""value""',                   'expected': ('key', '"value"', None)},
+            {'line': 'key = \'\'value\'\'',               'expected': ('key', "'value'", None)},
+            {'line': 'key="value',                        'expected': ('key', '"value', None)},
+            {'line': 'key  =  "value',                    'expected': ('key', '"value', None)},
+            {'line': ' key  =  "value ',                  'expected': ('key', '"value', None)},
+            {'line': 'key=value"',                        'expected': ('key', 'value"', None)},
+            {'line': 'key  =  value"',                    'expected': ('key', 'value"', None)},
+            {'line': ' key  =  value " ',                 'expected': ('key', 'value "', None)},
+            {'line': "key='value",                        'expected': ('key', "'value", None)},
+            {'line': "key  =  'value",                    'expected': ('key', "'value", None)},
+            {'line': " key  =  'value ",                  'expected': ('key', "'value", None)},
+            {'line': "key=value'",                        'expected': ('key', "value'", None)},
+            {'line': "key  =  value'",                    'expected': ('key', "value'", None)},
+            {'line': " key  =  value ' ",                 'expected': ('key', "value '", None)},
+        ]
+
+        for test in config_lines:
+            parsed_obj = p.parse(StringIO(test['line']))
+            parsed_obj = dict(parsed_obj)
+            expected = {test['expected'][0]: test['expected'][1]}
+            self.assertDictEqual(parsed_obj, expected,
+                    msg="Line %r" % (test['line']))
+
+    def testDefaultConfigFileParser_BlankValues(self):
+        p = configargparse.DefaultConfigFileParser()
+
+        # test the all syntax case
+        config_lines = [
+            {'line': 'key=',                              'expected': ('key', '', None)},
+            {'line': 'key =',                             'expected': ('key', '', None)},
+            {'line': 'key= ',                             'expected': ('key', '', None)},
+            {'line': 'key = ',                            'expected': ('key', '', None)},
+            {'line': 'key  =  ',                          'expected': ('key', '', None)},
+            {'line': ' key  =   ',                        'expected': ('key', '', None)},
+            {'line': 'key:',                              'expected': ('key', '', None)},
+            {'line': 'key :',                             'expected': ('key', '', None)},
+            {'line': 'key: ',                             'expected': ('key', '', None)},
+            {'line': 'key : ',                            'expected': ('key', '', None)},
+            {'line': 'key  :  ',                          'expected': ('key', '', None)},
+            {'line': ' key  :   ',                        'expected': ('key', '', None)},
+        ]
+
+        for test in config_lines:
+            parsed_obj = p.parse(StringIO(test['line']))
+            parsed_obj = dict(parsed_obj)
+            expected = {test['expected'][0]: test['expected'][1]}
+            self.assertDictEqual(parsed_obj, expected,
+                    msg="Line %r" % (test['line']))
+
+    def testDefaultConfigFileParser_UnspecifiedValues(self):
+        p = configargparse.DefaultConfigFileParser()
+
+        # test the all syntax case
+        config_lines = [
+            {'line': 'key ',                              'expected': ('key', 'true', None)},
+            {'line': 'key',                               'expected': ('key', 'true', None)},
+            {'line': 'key  ',                             'expected': ('key', 'true', None)},
+            {'line': ' key     ',                         'expected': ('key', 'true', None)},
+        ]
+
+        for test in config_lines:
+            parsed_obj = p.parse(StringIO(test['line']))
+            parsed_obj = dict(parsed_obj)
+            expected = {test['expected'][0]: test['expected'][1]}
+            self.assertDictEqual(parsed_obj, expected,
+                    msg="Line %r" % (test['line']))
+
+    def testDefaultConfigFileParser_ColonEqualSignValue(self):
+        p = configargparse.DefaultConfigFileParser()
+
+        # test the all syntax case
+        config_lines = [
+            {'line': 'key=:',                             'expected': ('key', ':', None)},
+            {'line': 'key =:',                            'expected': ('key', ':', None)},
+            {'line': 'key= :',                            'expected': ('key', ':', None)},
+            {'line': 'key = :',                           'expected': ('key', ':', None)},
+            {'line': 'key  =  :',                         'expected': ('key', ':', None)},
+            {'line': ' key  =  : ',                       'expected': ('key', ':', None)},
+            {'line': 'key:=',                             'expected': ('key', '=', None)},
+            {'line': 'key :=',                            'expected': ('key', '=', None)},
+            {'line': 'key: =',                            'expected': ('key', '=', None)},
+            {'line': 'key : =',                           'expected': ('key', '=', None)},
+            {'line': 'key  :  =',                         'expected': ('key', '=', None)},
+            {'line': ' key  :  = ',                       'expected': ('key', '=', None)},
+            {'line': 'key==',                             'expected': ('key', '=', None)},
+            {'line': 'key ==',                            'expected': ('key', '=', None)},
+            {'line': 'key= =',                            'expected': ('key', '=', None)},
+            {'line': 'key = =',                           'expected': ('key', '=', None)},
+            {'line': 'key  =  =',                         'expected': ('key', '=', None)},
+            {'line': ' key  =  = ',                       'expected': ('key', '=', None)},
+            {'line': 'key::',                             'expected': ('key', ':', None)},
+            {'line': 'key ::',                            'expected': ('key', ':', None)},
+            {'line': 'key: :',                            'expected': ('key', ':', None)},
+            {'line': 'key : :',                           'expected': ('key', ':', None)},
+            {'line': 'key  :  :',                         'expected': ('key', ':', None)},
+            {'line': ' key  :  : ',                       'expected': ('key', ':', None)},
+        ]
+
+        for test in config_lines:
+            parsed_obj = p.parse(StringIO(test['line']))
+            parsed_obj = dict(parsed_obj)
+            expected = {test['expected'][0]: test['expected'][1]}
+            self.assertDictEqual(parsed_obj, expected,
+                    msg="Line %r" % (test['line']))
+
+    def testDefaultConfigFileParser_ValuesWithComments(self):
+        p = configargparse.DefaultConfigFileParser()
+
+        # test the all syntax case
+        config_lines = [
+            {'line': 'key=value#comment ',                'expected': ('key', 'value#comment', None)},
+            {'line': 'key=value #comment',                'expected': ('key', 'value', 'comment')},
+            {'line': ' key  =  value  #  comment',        'expected': ('key', 'value', 'comment')},
+            {'line': 'key:value#comment',                 'expected': ('key', 'value#comment', None)},
+            {'line': 'key:value #comment',                'expected': ('key', 'value', 'comment')},
+            {'line': ' key  :  value  #  comment',        'expected': ('key', 'value', 'comment')},
+            {'line': 'key=value;comment ',                'expected': ('key', 'value;comment', None)},
+            {'line': 'key=value ;comment',                'expected': ('key', 'value', 'comment')},
+            {'line': ' key  =  value  ;  comment',        'expected': ('key', 'value', 'comment')},
+            {'line': 'key:value;comment',                 'expected': ('key', 'value;comment', None)},
+            {'line': 'key:value ;comment',                'expected': ('key', 'value', 'comment')},
+            {'line': ' key  :  value  ;  comment',        'expected': ('key', 'value', 'comment')},
+            {'line': 'key = value # comment # comment',   'expected': ('key', 'value', 'comment # comment')},
+            {'line': 'key = "value # comment" # comment', 'expected': ('key', 'value # comment', 'comment')},
+            {'line': 'key = "#" ; comment',               'expected': ('key', '#', 'comment')},
+            {'line': 'key = ";" # comment',               'expected': ('key', ';', 'comment')},
+        ]
+
+        for test in config_lines:
+            parsed_obj = p.parse(StringIO(test['line']))
+            parsed_obj = dict(parsed_obj)
+            expected = {test['expected'][0]: test['expected'][1]}
+            self.assertDictEqual(parsed_obj, expected,
+                    msg="Line %r" % (test['line']))
+
+    def testDefaultConfigFileParser_NegativeValues(self):
+        p = configargparse.DefaultConfigFileParser()
+
+        # test the all syntax case
+        config_lines = [
+            {'line': 'key = -10',                       'expected': ('key', '-10', None)},
+            {'line': 'key : -10',                       'expected': ('key', '-10', None)},
+            {'line': 'key -10',                         'expected': ('key', '-10', None)},
+            {'line': 'key = "-10"',                     'expected': ('key', '-10', None)},
+            {'line': "key  =  '-10'",                   'expected': ('key', '-10', None)},
+            {'line': 'key=-10',                         'expected': ('key', '-10', None)},
+        ]
+
+        for test in config_lines:
+            parsed_obj = p.parse(StringIO(test['line']))
+            parsed_obj = dict(parsed_obj)
+            expected = {test['expected'][0]: test['expected'][1]}
+            self.assertDictEqual(parsed_obj, expected,
+                    msg="Line %r" % (test['line']))
+
+    def testDefaultConfigFileParser_KeySyntax(self):
+        p = configargparse.DefaultConfigFileParser()
+
+        # test the all syntax case
+        config_lines = [
+            {'line': 'key_underscore = value',            'expected': ('key_underscore', 'value', None)},
+            {'line': 'key_underscore=',                   'expected': ('key_underscore', '', None)},
+            {'line': 'key_underscore',                    'expected': ('key_underscore', 'true', None)},
+            {'line': '_key_underscore = value',           'expected': ('_key_underscore', 'value', None)},
+            {'line': '_key_underscore=',                  'expected': ('_key_underscore', '', None)},
+            {'line': '_key_underscore',                   'expected': ('_key_underscore', 'true', None)},
+            {'line': 'key_underscore_ = value',           'expected': ('key_underscore_', 'value', None)},
+            {'line': 'key_underscore_=',                  'expected': ('key_underscore_', '', None)},
+            {'line': 'key_underscore_',                   'expected': ('key_underscore_', 'true', None)},
+            {'line': 'key-dash = value',                  'expected': ('key-dash', 'value', None)},
+            {'line': 'key-dash=',                         'expected': ('key-dash', '', None)},
+            {'line': 'key-dash',                          'expected': ('key-dash', 'true', None)},
+        ]
+
+        for test in config_lines:
+            parsed_obj = p.parse(StringIO(test['line']))
+            parsed_obj = dict(parsed_obj)
+            expected = {test['expected'][0]: test['expected'][1]}
+            self.assertDictEqual(parsed_obj, expected,
+                    msg="Line %r" % (test['line']))
+
     def testYAMLConfigFileParser_Basic(self):
         try:
             import yaml

--- a/tests/test_configargparse.py
+++ b/tests/test_configargparse.py
@@ -511,6 +511,46 @@ class TestBasicUseCases(TestCase):
             env_vars={"bla": "2"})
         self.assertEqual(set(args), {"--bla=3", "-x", "1"})
 
+
+    def testQuotedArgumentValues(self):
+        self.initParser()
+        self.add_arg("-a")
+        self.add_arg("--b")
+        self.add_arg("-c")
+        self.add_arg("--d")
+        self.add_arg("-e")
+        self.add_arg("-q")
+        self.add_arg("--quotes")
+
+        # sys.argv equivalent of -a="1"  --b "1" -c= --d "" -e=: -q "\"'" --quotes "\"'"
+        ns = self.parse(args=['-a=1', '--b', '1', '-c=', '--d', '', '-e=:',
+                '-q', '"\'', '--quotes', '"\''],
+                env_vars={}, config_file_contents="")
+
+        self.assertEqual(ns.a, "1")
+        self.assertEqual(ns.b, "1")
+        self.assertEqual(ns.c, "")
+        self.assertEqual(ns.d, "")
+        self.assertEqual(ns.e, ":")
+        self.assertEqual(ns.q, '"\'')
+        self.assertEqual(ns.quotes, '"\'')
+
+    def testQuotedConfigFileValues(self):
+        self.initParser()
+        self.add_arg("--a")
+        self.add_arg("--b")
+        self.add_arg("--c")
+
+        ns = self.parse(args="", env_vars={}, config_file_contents="""
+        a="1"
+        b=:
+        c=
+        """)
+
+        self.assertEqual(ns.a, "1")
+        self.assertEqual(ns.b, ":")
+        self.assertEqual(ns.c, "")
+
     def testBooleanValuesCanBeExpressedAsNumbers(self):
         self.initParser()
         store_true_env_var_name = "STORE_TRUE"

--- a/tests/test_configargparse.py
+++ b/tests/test_configargparse.py
@@ -1367,6 +1367,15 @@ class TestConfigFileParsers(TestCase):
             {'line': 'key-dash = value',                  'expected': ('key-dash', 'value', None)},
             {'line': 'key-dash=',                         'expected': ('key-dash', '', None)},
             {'line': 'key-dash',                          'expected': ('key-dash', 'true', None)},
+            {'line': 'key@word = value',                  'expected': ('key@word', 'value', None)},
+            {'line': 'key@word=',                         'expected': ('key@word', '', None)},
+            {'line': 'key@word',                          'expected': ('key@word', 'true', None)},
+            {'line': 'key$word = value',                  'expected': ('key$word', 'value', None)},
+            {'line': 'key$word=',                         'expected': ('key$word', '', None)},
+            {'line': 'key$word',                          'expected': ('key$word', 'true', None)},
+            {'line': 'key.word = value',                  'expected': ('key.word', 'value', None)},
+            {'line': 'key.word=',                         'expected': ('key.word', '', None)},
+            {'line': 'key.word',                          'expected': ('key.word', 'true', None)},
         ]
 
         for test in config_lines:


### PR DESCRIPTION
This allows for empty values: `key=` or `key=""`. This is different from specifying `key` without a value (with still sets `key` to "true").
Closes #103
Closes #136

This allows for negative values, or values that start with a dash: `key=-10`, `key=-A38E-8`
Closes #137 (though that most likely was already resolved by #160)

This allows to specify special characters, by putting them in quotes (either ' or " quotes): `key=":"`, `key="="`, `key="#"`, `key="'"`, `key='"'`, etc.

Also adds test suites to explicitly test for the different values and syntaxes. Beware that by adding these test suites some explicity choices are made in particular to the allowed syntax of keys. Previously keys may contain more or less any character (at least according to the parser). ~~Now, allowed characters are: 0-9A-Za-z_-. Thus, e.g. `key$name` or `key^name` is no longer allowed.~~ _Edit: This remains so in this version._