### PR TITLE
Allow setting counters in configfile.

### DIFF
--- a/configargparse.py
+++ b/configargparse.py
@@ -746,6 +746,11 @@ class ArgumentParser(argparse.ArgumentParser):
             elif value.lower() in ("false", "no", "0"):
                 # don't append when set to "false" / "no"
                 pass
+            elif isinstance(action, argparse._CountAction):
+                for arg in args:
+                    if any([arg.startswith(s) for s in action.option_strings]):
+                        value = 0
+                args += [action.option_strings[0]] * int(value)
             else:
                 self.error("Unexpected value for %s: '%s'. Expecting 'true', "
                            "'false', 'yes', 'no', '1' or '0'" % (key, value))

--- a/tests/test_configargparse.py
+++ b/tests/test_configargparse.py
@@ -703,6 +703,28 @@ class TestBasicUseCases(TestCase):
         self.assertEqual(ns.arg, ['Shell', 'someword', 'anotherword'])
         self.assertEqual(ns.a, "positional_value")
 
+    def testCounterCommandLine(self):
+        self.initParser()
+        self.add_arg("--verbose", "-v", action="count", default=0)
+
+        ns = self.parse(args="-v -v -v", env_vars={})
+        self.assertEqual(ns.verbose, 3)
+
+        ns = self.parse(args="-vvv", env_vars={})
+        self.assertEqual(ns.verbose, 3)
+
+    def testCounterConfigFile(self):
+        self.initParser()
+        self.add_arg("--verbose", "-v", action="count", default=0)
+
+        ns = self.parse(args="", env_vars={}, config_file_contents="""
+        verbose""")
+        self.assertEqual(ns.verbose, 1)
+
+        ns = self.parse(args="", env_vars={}, config_file_contents="""
+        verbose=3""")
+        self.assertEqual(ns.verbose, 3)
+
 class TestMisc(TestCase):
     # TODO test different action types with config file, env var
 


### PR DESCRIPTION
E.g. for an `action=count`, called `verbose`/`v`
you already could set `-v -v -v` (or `-vvv`) on the command line.

And you can now also set:
    verbose=3
in the configuration file.

Added two tests to verify current behaviour.
Note that it still is not possible to specify `-v=3` on the command line.

Credits to @christensonb for suggesting this fix in #138.
Closes #138
Closes #175