### PR TITLE
add ignore_help_args option to parse_known_args(..) 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ tests_require = [
 
 setup(
     name='ConfigArgParse',
-    version="1.4",
+    version="1.4.1",
     description='A drop-in replacement for argparse that allows options to '
                 'also be set via config files and/or environment variables.',
     long_description=long_description,

--- a/tests/test_configargparse.py
+++ b/tests/test_configargparse.py
@@ -311,6 +311,16 @@ class TestBasicUseCases(TestCase):
             output = out.getvalue().strip()
             self.assertEqual(output, expected_output)
 
+    def testIgnoreHelpArgs(self):
+        p = self.initParser()
+        self.add_arg('--arg1')
+        args, _ = self.parse_known('--arg2 --help', ignore_help_args=True)
+        self.assertEqual(args.arg1, None)
+        self.add_arg('--arg2')
+        args, _ = self.parse_known('--arg2 3 --help', ignore_help_args=True)
+        self.assertEqual(args.arg2, "3")
+        self.assertRaisesRegex(TypeError, "exit", self.parse_known, '--arg2 3 --help', ignore_help_args=False)
+
     def testPositionalAndConfigVarLists(self):
         self.initParser()
         self.add_arg("a")
@@ -320,7 +330,6 @@ class TestBasicUseCases(TestCase):
 
         self.assertEqual(ns.arg, ['Shell', 'someword', 'anotherword'])
         self.assertEqual(ns.a, "positional_value")
-
 
     def testMutuallyExclusiveArgs(self):
         config_file = tempfile.NamedTemporaryFile(mode="w", delete=True)


### PR DESCRIPTION
Add `ignore_help_args` option to parse_known_args(..) to avoid exiting the first time this method is called when -h is specified. This can allow all arg definitions to be executed before -h is handled, even if these definitions are interleaved with calls to parse_known_args(..)