### PR TITLE
Add support for no_config_file=True option in the add_argument() function

### DIFF
--- a/configargparse.py
+++ b/configargparse.py
@@ -583,7 +583,7 @@ class ArgumentParser(argparse.ArgumentParser):
                     action = known_config_keys[key]
                     # Support explicit no_config_file option to exclude some options from config
                     if getattr(action, 'no_config_file', None):
-                        raise ValueError(f"Not allowed to set option '{key}' from config file")
+                        self.error("Not allowed to set option '%s' from config file" % key)
                     discard_this_key = already_on_command_line(
                         args, action.option_strings, self.prefix_chars)
                 else:

--- a/configargparse.py
+++ b/configargparse.py
@@ -581,8 +581,9 @@ class ArgumentParser(argparse.ArgumentParser):
             for key, value in config_items.items():
                 if key in known_config_keys:
                     action = known_config_keys[key]
-                    # Support explicit no_config_file option to exclude some options from config
-                    if getattr(action, 'no_config_file', None):
+                    # Support explicit no_config_file option to exclude some options from config. 
+                    # Also raise error for the special case when one tries to set "help = true" from config file.
+                    if getattr(action, 'no_config_file', None) or action.dest == "help":
                         self.error("Not allowed to set option '%s' from config file" % key)
                     discard_this_key = already_on_command_line(
                         args, action.option_strings, self.prefix_chars)

--- a/tests/test_configargparse.py
+++ b/tests/test_configargparse.py
@@ -1477,6 +1477,14 @@ class TestConfigFileParsers(TestCase):
 
         self.assertDictEqual(parsed_obj, {'a': '3', 'list_arg': [1,2,3]})
 
+    def test_add_argument_no_config_file_option(self):
+
+        parser = configargparse.ArgumentParser()
+        parser.add_argument('--version', no_config_file=True, action='store_true')
+        parser.add_argument('--name',)
+
+        with self.assertRaisesRegex(ValueError, "Not allowed to set option 'version' from config file"):
+            parser.parse([], config_file_contents="\nname = bla4\nversion = true\n")
 
 
 ################################################################################

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37, py38, pypy, pypy3
+envlist = py27, py35, py36, py37, py38, py39, pypy, pypy3
 
 [testenv]
 #setenv = PYTHONPATH = {toxinidir}:{toxinidir}/configmanager


### PR DESCRIPTION
The docs of the new option read as follows:

```
no_config_file (bool): If True, this prevents the argument to be settable with 
            a config file. It will raise an exception if one tries to set this
            option from a file.
```

I think it's a necessary thing to exclude some option from the configuration file sometime!