### PR TITLE
Add API doc generation

### DIFF
--- a/.github/workflows/apidocs.yml
+++ b/.github/workflows/apidocs.yml
@@ -1,0 +1,27 @@
+name: apidocs
+on:
+- push
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install requirements for documentation generation
+      run: python -m pip install --upgrade pip setuptools wheel tox
+
+    - name: Generate API documentation with pydoctor
+      run: tox -e apidocs
+    
+    - name: Push API documentation to Github Pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./apidocs
+        commit_message: "Generate API documentation"

--- a/.github/workflows/apidocs.yml
+++ b/.github/workflows/apidocs.yml
@@ -1,6 +1,10 @@
 name: apidocs
+
 on:
-- push
+  push:
+    branches: [ master ]
+    tags: 
+      - '*'
 
 jobs:
   deploy:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+apidocs
+
 *.py[cod]
 
 # C extensions

--- a/apidocs.sh
+++ b/apidocs.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# This bash script builds the API documentation for ConfigArgParse.
+
+# Resolve source directory path. From https://stackoverflow.com/questions/59895/how-to-get-the-source-directory-of-a-bash-script-from-within-the-script-itself/246128#246128
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd $SCRIPT_DIR
+
+# Stop if errors
+set -euo pipefail
+IFS=$'\n\t,'
+
+# Figure the project version
+project_version="$(python3 setup.py -V)"
+
+# Figure commit ref
+git_sha="$(git rev-parse HEAD)"
+if ! git describe --exact-match --tags > /dev/null 2>&1 ; then
+    is_tag=false
+else
+    git_sha="$(git describe --exact-match --tags)"
+    is_tag=true
+fi
+
+# Init output folder
+docs_folder="./apidocs/"
+rm -rf "${docs_folder}"
+mkdir -p "${docs_folder}"
+
+# We generate the docs for the argparse module too, such that we can document 
+# the methods inherited from argparse.ArgumentParser, not only the methods that configargparse overrides.
+# And it help to have a better vision of the whole thing also.
+curl https://raw.githubusercontent.com/python/cpython/3.9/Lib/argparse.py > ./argparse.py
+echo "__docformat__ = 'restructuredtext'" >> ./argparse.py
+# Delete the file when the script exits
+trap "rm -f ./argparse.py" EXIT
+
+# Run pydoctor build
+pydoctor \
+    --project-name="ConfigArgParse ${project_version}" \
+    --project-url="https://github.com/bw2/ConfigArgParse" \
+    --html-viewsource-base="https://github.com/bw2/ConfigArgParse/tree/${git_sha}" \
+    --make-html \
+    --quiet \
+    --project-base-dir=.\
+    --docformat=google \
+    --html-output="${docs_folder}" \
+    ./argparse.py ./configargparse.py || true 
+    
+# There is currently an error 'Unknown target name: "foo".' in 
+# configargparse.ArgumentParser.__init__ that makes the build fails.
+# But ther than that, it looks good.
+
+echo "API docs generated in ${docs_folder}"

--- a/apidocs.sh
+++ b/apidocs.sh
@@ -43,7 +43,7 @@ pydoctor \
     --make-html \
     --quiet \
     --project-base-dir=.\
-    --docformat=plaintext \
+    --docformat=google \
     --html-output="${docs_folder}" \
     ./argparse.py ./configargparse.py || true 
 

--- a/apidocs.sh
+++ b/apidocs.sh
@@ -34,7 +34,6 @@ echo "__docformat__ = 'restructuredtext'" >> ./argparse.py
 # Delete the file when the script exits
 trap "rm -f ./argparse.py" EXIT
 
-# Run pydoctor build, we stick with plaintext for now but we could turn the google format parsing once I've solve 
 pydoctor \
     --project-name="ConfigArgParse ${project_version}" \
     --project-url="https://github.com/bw2/ConfigArgParse" \

--- a/apidocs.sh
+++ b/apidocs.sh
@@ -34,20 +34,17 @@ echo "__docformat__ = 'restructuredtext'" >> ./argparse.py
 # Delete the file when the script exits
 trap "rm -f ./argparse.py" EXIT
 
-# Run pydoctor build
+# Run pydoctor build, we stick with plaintext for now but we could turn the google format parsing once I've solve 
 pydoctor \
     --project-name="ConfigArgParse ${project_version}" \
     --project-url="https://github.com/bw2/ConfigArgParse" \
     --html-viewsource-base="https://github.com/bw2/ConfigArgParse/tree/${git_sha}" \
+    --intersphinx=https://docs.python.org/3/objects.inv \
     --make-html \
     --quiet \
     --project-base-dir=.\
-    --docformat=google \
+    --docformat=plaintext \
     --html-output="${docs_folder}" \
     ./argparse.py ./configargparse.py || true 
-    
-# There is currently an error 'Unknown target name: "foo".' in 
-# configargparse.ArgumentParser.__init__ that makes the build fails.
-# But ther than that, it looks good.
 
 echo "API docs generated in ${docs_folder}"

--- a/configargparse.py
+++ b/configargparse.py
@@ -83,8 +83,8 @@ class ConfigFileParser(object):
             stream: A config file input stream (such as an open file object).
 
         Returns:
-            OrderedDict of items where the keys have type string and the
-            values have type either string or list (eg. to support config file
+            OrderedDict: Items where the keys are strings and the
+            values are either strings or lists (eg. to support config file
             formats like YAML which allow lists).
         """
         raise NotImplementedError("parse(..) not implemented")
@@ -95,8 +95,8 @@ class ConfigFileParser(object):
 
         Args:
             items: an OrderedDict of items to be converted to the config file
-            format. Keys should be strings, and values should be either strings
-            or lists.
+                format. Keys should be strings, and values should be either strings
+                or lists.
 
         Returns:
             Contents of config file as a string
@@ -110,7 +110,7 @@ class ConfigFileParserException(Exception):
 
 class DefaultConfigFileParser(ConfigFileParser):
     """Based on a simplified subset of INI and YAML formats. Here is the
-    supported syntax:
+    supported syntax::
 
 
         # this is a comment
@@ -342,10 +342,10 @@ class ArgumentParser(argparse.ArgumentParser):
 
     def __init__(self, *args, **kwargs):
 
-        """Supports args of the argparse.ArgumentParser constructor
-        as **kwargs, as well as the following additional args.
+        r"""Supports args of the argparse.ArgumentParser constructor
+        as \*\*kwargs, as well as the following additional args.
 
-        Additional Args:
+        Arguments:
             add_config_file_help: Whether to add a description of config file
                 syntax to the help message.
             add_env_var_help: Whether to add something to the help message for
@@ -361,12 +361,14 @@ class ArgumentParser(argparse.ArgumentParser):
                 taking precedence over previous ones. This allows an application
                 to look for config files in multiple standard locations such as
                 the install directory, home directory, and current directory.
-                Also, shell * syntax can be used to specify all conf files in a
-                directory. For example:
-                ["/etc/conf/app_config.ini",
-                 "/etc/conf/conf-enabled/*.ini",
-                "~/.my_app_config.ini",
-                "./app_config.txt"]
+                Also, shell \* syntax can be used to specify all conf files in a
+                directory. For example::
+
+                    ["/etc/conf/app_config.ini",
+                    "/etc/conf/conf-enabled/*.ini",
+                    "~/.my_app_config.ini",
+                    "./app_config.txt"]
+
             ignore_unknown_config_file_keys: If true, settings that are found
                 in a config file but don't correspond to any defined
                 configargparse args will be ignored. If false, they will be
@@ -449,7 +451,7 @@ class ArgumentParser(argparse.ArgumentParser):
         """Supports all the same args as the ArgumentParser.parse_args(..),
         as well as the following additional args.
 
-        Additional Args:
+        Arguments:
             args: a list of args as in argparse, or a string (eg. "-x -y bla")
             config_file_contents: String. Used for testing.
             env_vars: Dictionary. Used for testing.
@@ -476,7 +478,7 @@ class ArgumentParser(argparse.ArgumentParser):
         """Supports all the same args as the ArgumentParser.parse_args(..),
         as well as the following additional args.
 
-        Additional Args:
+        Arguments:
             args: a list of args as in argparse, or a string (eg. "-x -y bla")
             config_file_contents (str). Used for testing.
             env_vars (dict). Used for testing.
@@ -692,7 +694,7 @@ class ArgumentParser(argparse.ArgumentParser):
             source_to_settings: the dictionary described in parse_known_args()
             parsed_namespace: namespace object created within parse_known_args()
         Returns:
-            an OrderedDict where keys are strings and values are either strings
+            OrderedDict: where keys are strings and values are either strings
             or lists
         """
         config_file_items = OrderedDict()
@@ -981,7 +983,7 @@ def add_argument(self, *args, **kwargs):
     This method supports the same args as ArgumentParser.add_argument(..)
     as well as the additional args below.
 
-    Additional Args:
+    Arguments:
         env_var: If set, the value of this environment variable will override
             any config file or default values for this arg (but can itself
             be overridden on the commandline). Also, if auto_env_var_prefix is

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ description = Build the API documentation
 
 deps = 
     docutils
-    git+https://github.com/twisted/pydoctor.git
+    git+https://github.com/tristanlatr/pydoctor.git@c1b2480719ee33422cf27416998e1874616cb2b1
 whitelist_externals = bash
 commands =
     bash ./apidocs.sh

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ description = Build the API documentation
 
 deps = 
     docutils
-    git+https://github.com/tristanlatr/pydoctor.git@31f22e09399daf6501a3493f45fddc0e38c29918
+    git+https://github.com/twisted/pydoctor.git
 whitelist_externals = bash
 commands =
     bash ./apidocs.sh

--- a/tox.ini
+++ b/tox.ini
@@ -30,3 +30,16 @@ basepython=pypy
 
 [testenv:pypy3]
 basepython=pypy3
+
+[testenv:apidocs]
+description = Build the API documentation
+
+# Google-style docstring parsing is not released yet, but it works like a charm.
+# TODO: Use released version of pydoctor when https://github.com/twisted/pydoctor/pull/358 is merged.
+
+deps = 
+    docutils
+    git+https://github.com/tristanlatr/pydoctor.git@31f22e09399daf6501a3493f45fddc0e38c29918
+whitelist_externals = bash
+commands =
+    bash ./apidocs.sh


### PR DESCRIPTION
This adds the API docs generation to the github workflow.

As well as the tox command `tox -e apidocs`. 

See #228 