### PR TITLE
Useful config parsers - TOML and INI parsers with support for sections

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -261,6 +261,128 @@ given below:
         
         args = parser.parse_args() # now args.system1 is a valid python dict
 
+*IniConfigParser*  - INI parser with support for sections.
+
+This parser somewhat ressembles ``ConfigparserConfigFileParser``. It uses configparser and apply the same kind of processing to 
+values written with python list syntax. 
+
+With the following additions: 
+   - Must be created with argument to bind the parser to a list of sections.
+   - Does not convert multiline strings to single line.
+   - Optional support for converting multiline strings to list (if ``split_ml_text_to_list=True``). 
+   - Optional support for quoting strings in config file 
+      (useful when text must not be converted to list or when text 
+      should contain trailing whitespaces).
+
+This config parser can be used to integrate with ``setup.cfg`` files.
+
+Example::
+
+      # this is a comment
+      ; also a comment
+      [my_super_tool]
+      # how to specify a key-value pair
+      format-string: restructuredtext 
+      # white space are ignored, so name = value same as name=value
+      # this is why you can quote strings 
+      quoted-string = '\thello\tmom...  '
+      # how to set an arg which has action="store_true"
+      warnings-as-errors = true
+      # how to set an arg which has action="count" or type=int
+      verbosity = 1
+      # how to specify a list arg (eg. arg which has action="append")
+      repeatable-option = ["https://docs.python.org/3/objects.inv",
+                     "https://twistedmatrix.com/documents/current/api/objects.inv"]
+      # how to specify a multiline text:
+      multi-line-text = 
+         Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
+         Vivamus tortor odio, dignissim non ornare non, laoreet quis nunc. 
+         Maecenas quis dapibus leo, a pellentesque leo. 
+
+If you use ``IniConfigParser(sections, split_ml_text_to_list=True)``::
+
+      # the same rules are applicable with the following changes:
+      [my-software]
+      # how to specify a list arg (eg. arg which has action="append")
+      repeatable-option = # Just enter one value per line (the list literal format can also be used)
+         https://docs.python.org/3/objects.inv
+         https://twistedmatrix.com/documents/current/api/objects.inv
+      # how to specify a multiline text (you have to quote it):
+      multi-line-text = '''
+         Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
+         Vivamus tortor odio, dignissim non ornare non, laoreet quis nunc. 
+         Maecenas quis dapibus leo, a pellentesque leo. 
+         '''
+
+Usage:
+
+.. code:: py
+
+   import configargparse
+   parser = configargparse.ArgParser(
+            default_config_files=['setup.cfg', 'my_super_tool.ini'],
+            config_file_parser_class=configargparse.IniConfigParser(['tool:my_super_tool', 'my_super_tool']),
+        )
+   ...
+
+*TomlConfigParser*  - TOML parser with support for sections.
+
+`TOML <https://github.com/toml-lang/toml/blob/main/toml.md>`_ parser. This config parser can be used to integrate with ``pyproject.toml`` files.
+
+Example::
+
+   # this is a comment
+   [tool.my-software] # TOML section table.
+   # how to specify a key-value pair
+   format-string = "restructuredtext" # strings must be quoted
+   # how to set an arg which has action="store_true"
+   warnings-as-errors = true
+   # how to set an arg which has action="count" or type=int
+   verbosity = 1
+   # how to specify a list arg (eg. arg which has action="append")
+   repeatable-option = ["https://docs.python.org/3/objects.inv",
+                  "https://twistedmatrix.com/documents/current/api/objects.inv"]
+   # how to specify a multiline text:
+   multi-line-text = '''
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
+      Vivamus tortor odio, dignissim non ornare non, laoreet quis nunc. 
+      Maecenas quis dapibus leo, a pellentesque leo. 
+      '''
+
+Usage:
+
+.. code:: py
+
+   import configargparse
+   parser = configargparse.ArgParser(
+            default_config_files=['pyproject.toml', 'my_super_tool.toml'],
+            config_file_parser_class=configargparse.TomlConfigParser(['tool.my_super_tool']),
+        )
+   ...
+
+*CompositeConfigParser*  - Create a config parser to understand multiple formats.
+
+This parser will successively try to parse the file with each parser, until it succeeds, 
+else fail showing all encountered error messages.
+
+The following code will make configargparse understand both TOML and INI formats. 
+Making it easy to integrate in both ``pyproject.toml`` and ``setup.cfg``.
+
+.. code:: py
+
+   import configargparse
+   my_tool_sections = ['tool.my_super_tool', 'tool:my_super_tool', 'my_super_tool']
+                    # pyproject.toml like section, setup.cfg like section, custom section
+   parser = configargparse.ArgParser(
+            default_config_files=['setup.cfg', 'my_super_tool.ini'],
+            config_file_parser_class=configargparse.CompositeConfigParser(
+               [configargparse.TomlConfigParser(my_tool_sections), 
+                configargparse.IniConfigParser(my_tool_sections, split_ml_text_to_list=True)]
+               ),
+        )
+   ...
+
+Note that it's required to put the TOML parser first because the INI syntax basically would accept anything whereas TOML. 
 
 ArgParser Singletons
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -448,11 +570,15 @@ Design choices:
    file (eg. short args like -x would be excluded). Also, that way
    config keys are automatically documented whenever the command line
    args are documented in the help message.
-5. don't force users to put config file settings in the right .ini
-   [sections]. This doesn't have a clear benefit since all options are
-   command-line settable, and so have a globally unique key anyway.
-   Enforcing sections just makes things harder for the user and adds
-   complexity to the implementation.
+5. > don't force users to put config file settings in the right .ini
+      [sections]. This doesn't have a clear benefit since all options are
+      command-line settable, and so have a globally unique key anyway.
+      Enforcing sections just makes things harder for the user and adds
+      complexity to the implementation.
+   This design choice is preventing configargparse to fully integrate 
+   with common Python project config file like setup.cfg or pyproject.toml. 
+   This is why some additionnal parser classes are included that parses only 
+   a subset of the values defined in INI or TOML config files.
 6. if necessary, config-file-only args can be added later by
    implementing a separate add method and using the namespace arg as in
    appsettings_v0.5

--- a/configargparse.py
+++ b/configargparse.py
@@ -441,13 +441,18 @@ class TomlConfigParser(ConfigFileParser):
     Create a TOML parser bounded to the list of provided sections.
 
     Example::
-
-        [tool.my-software]
+        # this is a comment
+        [tool.my-software] # TOML section table.
+        # how to specify a key-value pair
+        format-string = "restructuredtext" # strings must be quoted
+        # how to set an arg which has action="store_true"
+        warnings-as-errors = true
+        # how to set an arg which has action="count" or type=int
+        verbosity = 1
+        # how to specify a list arg (eg. arg which has action="append")
         repeatable-option = ["https://docs.python.org/3/objects.inv",
                        "https://twistedmatrix.com/documents/current/api/objects.inv"]
-        format-string = "restructuredtext"
-        verbose = 1
-        warnings-as-errors = true
+        # how to specify a multiline text:
         multi-line-text = '''
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
             Vivamus tortor odio, dignissim non ornare non, laoreet quis nunc. 
@@ -510,14 +515,22 @@ class IniConfigParser(ConfigFileParser):
 
     Example (if split_ml_text_to_list=False)::
 
+        # this is a comment
+        ; also a comment
         [my-software]
+        # how to specify a key-value pair
+        format-string: restructuredtext 
+        # white space are ignored, so name = value same as name=value
+        # this is why you can quote strings 
+        quoted-string = '\thello\tmom...  '
+        # how to set an arg which has action="store_true"
+        warnings-as-errors = true
+        # how to set an arg which has action="count" or type=int
+        verbosity = 1
+        # how to specify a list arg (eg. arg which has action="append")
         repeatable-option = ["https://docs.python.org/3/objects.inv",
                        "https://twistedmatrix.com/documents/current/api/objects.inv"]
-        format-string = restructuredtext
-        verbose = 1
-        warnings-as-errors = true
-        privacy = ["HIDDEN:pydoctor.test",
-                   "PUBLIC:pydoctor._configparser",]
+        # how to specify a multiline text:
         multi-line-text = 
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
             Vivamus tortor odio, dignissim non ornare non, laoreet quis nunc. 
@@ -525,22 +538,18 @@ class IniConfigParser(ConfigFileParser):
     
     Example (if split_ml_text_to_list=True)::
 
+        # the same rules are applicable with the following changes:
         [my-software]
-        repeatable-option =
+        # how to specify a list arg (eg. arg which has action="append")
+        repeatable-option = # Just enter one value per line (the list literal format can also be used)
             https://docs.python.org/3/objects.inv
             https://twistedmatrix.com/documents/current/api/objects.inv
-        format-string = restructuredtext
-        verbose = 1
-        warnings-as-errors = true
-        privacy =
-            HIDDEN:pydoctor.test
-            PUBLIC:pydoctor._configparser
+        # how to specify a multiline text (you have to quote it):
         multi-line-text = '''
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
             Vivamus tortor odio, dignissim non ornare non, laoreet quis nunc. 
             Maecenas quis dapibus leo, a pellentesque leo. 
             '''
-    
     """
 
     def __init__(self, sections, split_ml_text_to_list):
@@ -638,8 +647,9 @@ class CompositeConfigParser(ConfigFileParser):
     
     def get_syntax_description(self) :
         def guess_format_name(classname):
-            return classname.strip('_').replace('Parser', 
-                '').replace('Config', '').replace('File', '').upper()
+            strip = classname.lower().strip('_').replace('parser', 
+                '').replace('config', '').replace('file', '')
+            return strip.upper() if strip else '??'
         
         msg = "Uses multiple config parser settings (in order): \n"
         for i, parser in enumerate(self.parsers): 

--- a/configargparse.py
+++ b/configargparse.py
@@ -900,7 +900,7 @@ class ArgumentParser(argparse.ArgumentParser):
             try:
                 config_items = self._config_file_parser.parse(stream)
             except ConfigFileParserException as e:
-                self.error(e)
+                self.error(str(e))
             finally:
                 if hasattr(stream, "close"):
                     stream.close()

--- a/configargparse.py
+++ b/configargparse.py
@@ -338,17 +338,17 @@ class YAMLConfigFileParser(ConfigFileParser):
 
 
 """
-Provides L{configargparse.ConfigFileParser} classes to parse C{TOML} and C{INI} files with **mandatory** support for sections.
-Useful to integrate configuration into project files like C{pyproject.toml} or C{setup.cfg}.
+Provides `configargparse.ConfigFileParser` classes to parse ``TOML`` and ``INI`` files with **mandatory** support for sections.
+Useful to integrate configuration into project files like ``pyproject.toml`` or ``setup.cfg``.
 
-L{TomlConfigParser} usage: 
+`TomlConfigParser` usage: 
 
 >>> TomlParser = TomlConfigParser(['tool.my_super_tool']) # Simple TOML parser.
 >>> parser = ArgumentParser(..., default_config_files=['./pyproject.toml'], config_file_parser_class=TomlParser)
 
-L{IniConfigParser} works the same way (also it optionaly convert multiline strings to list with argument C{split_ml_text_to_list}).
+`IniConfigParser` works the same way (also it optionaly convert multiline strings to list with argument ``split_ml_text_to_list``).
 
-L{CompositeConfigParser} usage:
+`CompositeConfigParser` usage:
 
 >>> MY_CONFIG_SECTIONS = ['tool.my_super_tool', 'tool:my_super_tool', 'my_super_tool']
 >>> TomlParser =  TomlConfigParser(MY_CONFIG_SECTIONS)
@@ -376,7 +376,7 @@ def is_quoted(text, triple=True):
     """
     Detect whether a string is a quoted representation. 
 
-    @param triple: Also match tripple quoted strings.
+    :param triple: Also match tripple quoted strings.
     """
     return bool(_QUOTED_STR_REGEX.match(text)) or \
         (triple and bool(_TRIPLE_QUOTED_STR_REGEX.match(text)))
@@ -385,9 +385,9 @@ def unquote_str(text, triple=True):
     """
     Unquote a maybe quoted string representation. 
     If the string is not detected as being a quoted representation, it returns the same string as passed.
-    It supports all kinds of python quotes: C{\"\"\"}, C{'''}, C{"} and C{'}.
+    It supports all kinds of python quotes: ``\"\"\"``, ``'''``, ``"`` and ``'``.
 
-    @param triple: Also unquote tripple quoted strings.
+    :param triple: Also unquote tripple quoted strings.
     @raises ValueError: If the string is detected as beeing quoted but literal_eval() fails to evaluate it as string.
         This would be a bug in the regex. 
     """
@@ -421,8 +421,8 @@ def parse_toml_section_name(section_name):
 
 def get_toml_section(data, section):
     """
-    Given some TOML data (as loaded with L{toml.load()}), returns the requested section of the data.
-    Returns C{None} if the section is not found.
+    Given some TOML data (as loaded with `toml.load()`), returns the requested section of the data.
+    Returns ``None`` if the section is not found.
     """
     sections = parse_toml_section_name(section) if isinstance(section, str) else section
     itemdata = data.get(sections[0])
@@ -612,7 +612,7 @@ class IniConfigParser(ConfigFileParser):
 
 class CompositeConfigParser(ConfigFileParser):
     """
-    Createa a config parser composed by others L{ConfigFileParser}s.  
+    Createa a config parser composed by others `ConfigFileParser`s.  
 
     The composite parser will successively try to parse the file with each parser, 
     until it succeeds, else raise execption with all encountered errors. 

--- a/configargparse.py
+++ b/configargparse.py
@@ -4,6 +4,9 @@ A drop-in replacement for `argparse` that allows options to also be set via conf
 :see: `configargparse.ArgumentParser`, `configargparse.add_argument`
 """
 import argparse
+import ast
+import csv
+import functools
 import json
 import glob
 import os
@@ -333,6 +336,255 @@ class YAMLConfigFileParser(ConfigFileParser):
         items = dict(items)
         return yaml.dump(items, default_flow_style=default_flow_style)
 
+
+"""
+Provides L{configargparse.ConfigFileParser} classes to parse C{TOML} and C{INI} files with **mandatory** support for sections.
+Useful to integrate configuration into project files like C{pyproject.toml} or C{setup.cfg}.
+
+L{TomlConfigParser} usage: 
+
+>>> TomlParser = TomlConfigParser(['tool.my_super_tool']) # Simple TOML parser.
+>>> parser = ArgumentParser(..., default_config_files=['./pyproject.toml'], config_file_parser_class=TomlParser)
+
+L{IniConfigParser} works the same way (also it optionaly convert multiline strings to list with argument C{split_ml_text_to_list}).
+
+L{CompositeConfigParser} usage:
+
+>>> MY_CONFIG_SECTIONS = ['tool.my_super_tool', 'tool:my_super_tool', 'my_super_tool']
+>>> TomlParser =  TomlConfigParser(MY_CONFIG_SECTIONS)
+>>> IniParser = IniConfigParser(MY_CONFIG_SECTIONS, split_ml_text_to_list=True)
+>>> MixedParser = CompositeConfigParser([TomlParser, IniParser]) # This parser supports both TOML and INI formats.
+>>> parser = ArgumentParser(..., default_config_files=['./pyproject.toml', 'setup.cfg', 'my_super_tool.ini'], config_file_parser_class=MixedParser)
+
+"""
+
+# I did not invented these regex, just put together some stuff from:
+# - https://stackoverflow.com/questions/11859442/how-to-match-string-in-quotes-using-regex
+# - and https://stackoverflow.com/a/41005190
+
+_QUOTED_STR_REGEX = re.compile(r'(^\"(?:\\.|[^\"\\])*\"$)|'
+                               r'(^\'(?:\\.|[^\'\\])*\'$)')
+
+_TRIPLE_QUOTED_STR_REGEX = re.compile(r'(^\"\"\"(\s+)?(([^\"]|\"([^\"]|\"[^\"]))*(\"\"?)?)?(\s+)?(?:\\.|[^\"\\])?\"\"\"$)|'
+                                                                                                 # Unescaped quotes at the end of a string generates 
+                                                                                                 # "SyntaxError: EOL while scanning string literal", 
+                                                                                                 # so we don't account for those kind of strings as quoted.
+                                      r'(^\'\'\'(\s+)?(([^\']|\'([^\']|\'[^\']))*(\'\'?)?)?(\s+)?(?:\\.|[^\'\\])?\'\'\'$)', flags=re.DOTALL)
+
+@functools.lru_cache(maxsize=256, typed=True)
+def is_quoted(text:str, triple:bool=True) -> bool:
+    """
+    Detect whether a string is a quoted representation. 
+
+    @param triple: Also match tripple quoted strings.
+    """
+    return bool(_QUOTED_STR_REGEX.match(text)) or \
+        (triple and bool(_TRIPLE_QUOTED_STR_REGEX.match(text)))
+
+def unquote_str(text:str, triple:bool=True) -> str:
+    """
+    Unquote a maybe quoted string representation. 
+    If the string is not detected as being a quoted representation, it returns the same string as passed.
+    It supports all kinds of python quotes: C{\"\"\"}, C{'''}, C{"} and C{'}.
+
+    @param triple: Also unquote tripple quoted strings.
+    @raises ValueError: If the string is detected as beeing quoted but literal_eval() fails to evaluate it as string.
+        This would be a bug in the regex. 
+    """
+    if is_quoted(text, triple=triple):
+        try:
+            s = ast.literal_eval(text)
+            assert isinstance(s, str)
+        except Exception as e:
+            raise ValueError(f"Error trying to unquote the quoted string: {text}: {e}") from e
+        return s
+    return text
+
+def parse_toml_section_name(section_name:str) -> Tuple[str, ...]:
+    """
+    Parse a TOML section name to a sequence of strings.
+
+    The following names are all valid: 
+
+    .. python::
+
+        "a.b.c"            # this is best practice -> returns ("a", "b", "c")
+        " d.e.f "          # same as [d.e.f] -> returns ("d", "e", "f")
+        " g .  h  . i "    # same as [g.h.i] -> returns ("g", "h", "i")
+        ' j . "ʞ" . "l" '  # same as [j."ʞ"."l"], double or simple quotes here are supported. -> returns ("j", "ʞ", "l")
+    """
+    section = []
+    for row in csv.reader([section_name], delimiter='.'):
+        for a in row:
+            section.append(unquote_str(a.strip(), triple=False))
+    return tuple(section)
+
+def get_toml_section(data:Dict[str, Any], section:Union[Tuple[str, ...], str]) -> Optional[Dict[str, Any]]:
+    """
+    Given some TOML data (as loaded with L{toml.load()}), returns the requested section of the data.
+    Returns C{None} if the section is not found.
+    """
+    sections = parse_toml_section_name(section) if isinstance(section, str) else section
+    itemdata = data.get(sections[0])
+    if not itemdata:
+        return None
+    sections = sections[1:]
+    if sections:
+        return get_toml_section(itemdata, sections)
+    else:
+        if not isinstance(itemdata, dict):
+            return None
+        return itemdata
+
+class TomlConfigParser(ConfigFileParser):
+    """
+    Create a TOML parser bounded to the list of provided sections.
+    """
+
+    def __init__(self, sections: List[str]) -> None:
+        super().__init__()
+        self.sections = sections
+    
+    def __call__(self) -> ConfigFileParser:
+        return self
+
+    def parse(self, stream:TextIO) -> Dict[str, Any]:
+        """Parses the keys and values from a TOML config file."""
+        # parse with configparser to allow multi-line values
+        import toml
+        try:
+            config = toml.load(stream)
+        except Exception as e:
+            raise ConfigFileParserException("Couldn't parse TOML file: %s" % e)
+
+        # convert to dict and filter based on section names
+        result: Dict[str, Any] = OrderedDict()
+
+        for section in self.sections:
+            data = get_toml_section(config, section)
+            if data:
+                # Seems a little weird, but anything that is not a list is converted to string, 
+                # It will be converted back to boolean, int or whatever after.
+                # Because config values are still passed to argparser for computation.
+                for key, value in data.items():
+                    if isinstance(value, list):
+                        result[key] = value
+                    elif value is None:
+                        pass
+                    else:
+                        result[key] = str(value)
+                break
+        
+        return result
+
+    def get_syntax_description(self) -> str:
+        return ("Config file syntax is Tom's Obvious, Minimal Language. "
+                "See https://github.com/toml-lang/toml/blob/v0.5.0/README.md for details.")
+
+class IniConfigParser(ConfigFileParser):
+    """
+    Create a INI parser bounded to the list of provided sections.
+    Optionaly convert multiline strings to list.
+    """
+
+    def __init__(self, sections:List[str], split_ml_text_to_list:bool) -> None:
+        super().__init__()
+        self.sections = sections
+        self.split_ml_text_to_list = split_ml_text_to_list
+
+    def __call__(self) -> ConfigFileParser:
+        return self
+
+    def parse(self, stream:TextIO) -> Dict[str, Any]:
+        """Parses the keys and values from an INI config file."""
+        # parse with configparser to allow multi-line values
+        import configparser
+        config = configparser.ConfigParser()
+        try:
+            config.read_string(stream.read())
+        except Exception as e:
+            raise ConfigFileParserException("Couldn't parse INI file: %s" % e)
+
+        # convert to dict and filter based on INI section names
+        result = OrderedDict()
+        for section in config.sections() + [configparser.DEFAULTSECT]:
+            if section not in self.sections:
+                continue
+            for k,v in config[section].items():
+                strip_v = v.strip()
+                if not strip_v:
+                    # ignores empty values, anyway allow_no_value=False by default so this should not happend.
+                    continue
+                # evaluate lists
+                if strip_v.startswith('[') and strip_v.endswith(']'):
+                    try:
+                        result[k] = ast.literal_eval(strip_v)
+                    except ValueError as e:
+                        # error evaluating object
+                        raise ConfigFileParserException("Error evaluating list: " + str(e) + ". Put quotes around your text if it's meant to be a string.") from e
+                else:
+                    if is_quoted(strip_v):
+                        # evaluate quoted string
+                        try:
+                            result[k] = unquote_str(strip_v)
+                        except ValueError as e:
+                            # error unquoting string
+                            raise ConfigFileParserException(str(e)) from e
+                    # split multi-line text into list of strings if split_ml_text_to_list is enabled.
+                    elif self.split_ml_text_to_list and '\n' in v.rstrip('\n'):
+                        try:
+                            result[k] = [unquote_str(i) for i in strip_v.split('\n') if i]
+                        except ValueError as e:
+                            # error unquoting string
+                            raise ConfigFileParserException(str(e)) from e
+                    else:
+                        result[k] = v
+        return result
+
+    def get_syntax_description(self) -> str:
+        msg = ("Uses configparser module to parse an INI file which allows multi-line values. "
+                "See https://docs.python.org/3/library/configparser.html for details. "
+                "This parser includes support for quoting strings literal as well as python list syntax evaluation. ")
+        if self.split_ml_text_to_list:
+            msg += ("Alternatively lists can be constructed with a plain multiline string, "
+                "each non-empty line will be converted to a list item.")
+        return msg
+
+class CompositeConfigParser(ConfigFileParser):
+    """
+    Createa a config parser composed by others L{ConfigFileParser}s.  
+
+    The composite parser will successively try to parse the file with each parser, 
+    until it succeeds, else raise execption with all encountered errors. 
+    """
+
+    def __init__(self, config_parser_types: List[Callable[[], ConfigFileParser]]) -> None:
+        super().__init__()
+        self.parsers = [p() for p in config_parser_types]
+
+    def __call__(self) -> ConfigFileParser:
+        return self
+
+    def parse(self, stream:TextIO) -> Dict[str, Any]:
+        errors = []
+        for p in self.parsers:
+            try:
+                return p.parse(stream) # type: ignore[no-any-return]
+            except Exception as e:
+                stream.seek(0)
+                errors.append(e)
+        raise ConfigFileParserException(
+                f"Error parsing config: {', '.join(repr(str(e)) for e in errors)}")
+    
+    def get_syntax_description(self) -> str:
+        def guess_format_name(classname:str) -> str:
+            return classname.strip('_').replace('Parser', 
+                '').replace('Config', '').replace('File', '').upper()
+        
+        msg = "Uses multiple config parser settings (in order): \n"
+        for i, parser in enumerate(self.parsers): 
+            msg += f"[{i+1}] {guess_format_name(parser.__class__.__name__)}: {parser.get_syntax_description()} \n"
+        return msg
 
 # used while parsing args to keep track of where they came from
 _COMMAND_LINE_SOURCE_KEY = "command_line"

--- a/configargparse.py
+++ b/configargparse.py
@@ -372,7 +372,7 @@ _TRIPLE_QUOTED_STR_REGEX = re.compile(r'(^\"\"\"(\s+)?(([^\"]|\"([^\"]|\"[^\"]))
                                       r'(^\'\'\'(\s+)?(([^\']|\'([^\']|\'[^\']))*(\'\'?)?)?(\s+)?(?:\\.|[^\'\\])?\'\'\'$)', flags=re.DOTALL)
 
 @functools.lru_cache(maxsize=256, typed=True)
-def is_quoted(text:str, triple:bool=True) -> bool:
+def is_quoted(text, triple=True):
     """
     Detect whether a string is a quoted representation. 
 
@@ -381,7 +381,7 @@ def is_quoted(text:str, triple:bool=True) -> bool:
     return bool(_QUOTED_STR_REGEX.match(text)) or \
         (triple and bool(_TRIPLE_QUOTED_STR_REGEX.match(text)))
 
-def unquote_str(text:str, triple:bool=True) -> str:
+def unquote_str(text, triple=True):
     """
     Unquote a maybe quoted string representation. 
     If the string is not detected as being a quoted representation, it returns the same string as passed.
@@ -400,7 +400,7 @@ def unquote_str(text:str, triple:bool=True) -> str:
         return s
     return text
 
-def parse_toml_section_name(section_name:str) -> Tuple[str, ...]:
+def parse_toml_section_name(section_name):
     """
     Parse a TOML section name to a sequence of strings.
 
@@ -419,7 +419,7 @@ def parse_toml_section_name(section_name:str) -> Tuple[str, ...]:
             section.append(unquote_str(a.strip(), triple=False))
     return tuple(section)
 
-def get_toml_section(data:Dict[str, Any], section:Union[Tuple[str, ...], str]) -> Optional[Dict[str, Any]]:
+def get_toml_section(data, section):
     """
     Given some TOML data (as loaded with L{toml.load()}), returns the requested section of the data.
     Returns C{None} if the section is not found.
@@ -441,14 +441,14 @@ class TomlConfigParser(ConfigFileParser):
     Create a TOML parser bounded to the list of provided sections.
     """
 
-    def __init__(self, sections: List[str]) -> None:
+    def __init__(self, sections):
         super().__init__()
         self.sections = sections
     
-    def __call__(self) -> ConfigFileParser:
+    def __call__(self):
         return self
 
-    def parse(self, stream:TextIO) -> Dict[str, Any]:
+    def parse(self, stream):
         """Parses the keys and values from a TOML config file."""
         # parse with configparser to allow multi-line values
         import toml
@@ -458,7 +458,7 @@ class TomlConfigParser(ConfigFileParser):
             raise ConfigFileParserException("Couldn't parse TOML file: %s" % e)
 
         # convert to dict and filter based on section names
-        result: Dict[str, Any] = OrderedDict()
+        result = OrderedDict()
 
         for section in self.sections:
             data = get_toml_section(config, section)
@@ -477,7 +477,7 @@ class TomlConfigParser(ConfigFileParser):
         
         return result
 
-    def get_syntax_description(self) -> str:
+    def get_syntax_description(self):
         return ("Config file syntax is Tom's Obvious, Minimal Language. "
                 "See https://github.com/toml-lang/toml/blob/v0.5.0/README.md for details.")
 
@@ -487,15 +487,15 @@ class IniConfigParser(ConfigFileParser):
     Optionaly convert multiline strings to list.
     """
 
-    def __init__(self, sections:List[str], split_ml_text_to_list:bool) -> None:
+    def __init__(self, sections, split_ml_text_to_list):
         super().__init__()
         self.sections = sections
         self.split_ml_text_to_list = split_ml_text_to_list
 
-    def __call__(self) -> ConfigFileParser:
+    def __call__(self):
         return self
 
-    def parse(self, stream:TextIO) -> Dict[str, Any]:
+    def parse(self, stream):
         """Parses the keys and values from an INI config file."""
         # parse with configparser to allow multi-line values
         import configparser
@@ -541,7 +541,7 @@ class IniConfigParser(ConfigFileParser):
                         result[k] = v
         return result
 
-    def get_syntax_description(self) -> str:
+    def get_syntax_description(self):
         msg = ("Uses configparser module to parse an INI file which allows multi-line values. "
                 "See https://docs.python.org/3/library/configparser.html for details. "
                 "This parser includes support for quoting strings literal as well as python list syntax evaluation. ")
@@ -558,14 +558,14 @@ class CompositeConfigParser(ConfigFileParser):
     until it succeeds, else raise execption with all encountered errors. 
     """
 
-    def __init__(self, config_parser_types: List[Callable[[], ConfigFileParser]]) -> None:
+    def __init__(self, config_parser_types):
         super().__init__()
         self.parsers = [p() for p in config_parser_types]
 
-    def __call__(self) -> ConfigFileParser:
+    def __call__(self):
         return self
 
-    def parse(self, stream:TextIO) -> Dict[str, Any]:
+    def parse(self, stream):
         errors = []
         for p in self.parsers:
             try:
@@ -576,8 +576,8 @@ class CompositeConfigParser(ConfigFileParser):
         raise ConfigFileParserException(
                 f"Error parsing config: {', '.join(repr(str(e)) for e in errors)}")
     
-    def get_syntax_description(self) -> str:
-        def guess_format_name(classname:str) -> str:
+    def get_syntax_description(self) :
+        def guess_format_name(classname):
             return classname.strip('_').replace('Parser', 
                 '').replace('Config', '').replace('File', '').upper()
         


### PR DESCRIPTION
Hello @bw2, 

This PR adds TOML and INI parsers with support for sections.

This PR solves issues #250, #227 and #20. 

I know you manifested medium interest into this feature, but I'm sending a PR anyway because I think I propose a good way to integrate `configargparse` config parsing with standard project config files likes `setup.cfg` or `pyproject.toml`. 

I've added pretty extensive documentation, so everything should be clear by reading the readme additions. 

Tell me if you are interested into merging this kind of feature, I think it would be very useful (and I'm not the only one). 
I did not migrated the tests yet, I wanted to hear back from you before continuing working on this. 

Tell me what you think :)

Thanks