### PR TITLE
Update yaml doc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -209,6 +209,10 @@ classes: :code:`DefaultConfigFileParser`, :code:`YAMLConfigFileParser`,
 
         fruit: [apple, orange, lemon]
         indexes: [1, 12, 35, 40]
+        colors:
+          - green
+          - red
+          - blue
 
 *ConfigparserConfigFileParser*  - allows a subset of python's configparser
 module syntax (https://docs.python.org/3.7/library/configparser.html). In


### PR DESCRIPTION
Hi,

A nice way of using lists in yaml is 
```
my_variable:
  - value1
  - value2
  - value3
```

Naively following the documentation to initially set up ConfigArgParse it seemed to accept some yaml input

```
name: value    # (yaml style)
```

but not the above mentioned type of list. 

There is a quote about "subset of YAML syntax".

However, it turns out that the yaml style list is supported.   ;-)    Since that's the case, could be a bit clearer to show it in the docs.