### PR TITLE
Remove Python 2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ python:
   - 3.7
   - 3.6
   - 3.5
-  - 2.7
   - pypy
   - pypy3
 jobs:

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Features
 -  extensible (:code:`ConfigFileParser` can be subclassed to define a new
    config file format)
 -  unittested by running the unittests that came with argparse but on
-   configargparse, and using tox to test with Python 2.7 and Python 3+
+   configargparse, and using tox to test with Python 3.5+
 
 Example
 ~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -97,8 +97,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
-        "Programming Language :: Python :: 2",
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
@@ -111,7 +109,7 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
     test_suite='tests',
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+    python_requires='>=3.5',
     install_requires=install_requires,
     tests_require=tests_require,
     extras_require = {

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,11 @@
 [tox]
-envlist = py27, py35, py36, py37, py38, py39, py310, py311, pypy, pypy3
+envlist = py35, py36, py37, py38, py39, py310, py311, pypy, pypy3
 
 [testenv]
 #setenv = PYTHONPATH = {toxinidir}:{toxinidir}/configmanager
 
 commands = python setup.py test
            # python -m unittest discover
-
-[testenv:py27]
-basepython=python2.7
 
 [testenv:py35]
 basepython=python3.5


### PR DESCRIPTION
Now import `configargparse` on Python 2 fail
```
Python 2.7.18 (default, Jul  1 2022, 12:27:04)
[GCC 9.4.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import configargparse
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "configargparse.py", line 406
    raise ValueError(f"Error trying to unquote the quoted string: {text}: {e}") from e
                                                                             ^
SyntaxError: invalid syntax
>>>
```