### PR TITLE
Handle pathlib Path used as default_config_files

### DIFF
--- a/configargparse.py
+++ b/configargparse.py
@@ -1328,7 +1328,7 @@ class ArgumentParser(argparse.ArgumentParser):
                 if config_arg_string:
                     config_arg_string = "specified via " + config_arg_string
                 if default_config_files or config_arg_string:
-                    msg += " (%s)." % " or ".join(tuple(default_config_files) +
+                    msg += " (%s)." % " or ".join(tuple(map(str, default_config_files)) +
                                                   tuple(filter(None, [config_arg_string])))
                 msg += " " + self._config_file_parser.get_syntax_description()
 


### PR DESCRIPTION
Having `Path` objects in the default_config_files make it impossible to display the help (-h) message

```python
from pathlib import Path

import configargparse

p = configargparse.ArgumentParser(default_config_files=[Path("~/.my_settings.ini")])
p.add("geotiff")
p.add("--flag", help="Flag that can be set in the config file")

options = p.parse_args()
```

Running the above snippet with -h will trigger a `TypeError: sequence item 0: expected str instance, PosixPath found`.


This PR just casts the default_config_files to str in the help message.