### PR TITLE
Update release action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,8 +59,9 @@ jobs:
           pytest
 
   release:
-      needs: [ test ]
+      needs: test
       name: PyPI
+      if: startsWith(github.ref, 'refs/tags/')
       runs-on: ubuntu-latest
       environment: pypi
       permissions:
@@ -83,5 +84,4 @@ jobs:
             ls -alh ./dist/
 
         - name: Publish to PyPI - on tag
-          if: startsWith(github.ref, 'refs/tags/')
           uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
It is VERY scary to see this in your PR.

<img width="703" alt="image" src="https://github.com/user-attachments/assets/ff329bc2-8cf0-4f08-92e9-aee2bb173aae" />

Moves the `if` up, so the step just does not run at all..