### PR TITLE
Adds file to ignore blame of certain commits

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,7 @@
+# .git-blame-ignore-revs used to ignore SHAs from git blame
+# applied automatically in Github, use the command
+# `git config blame.ignoreRevsFile .git-blame-ignore-revs` to config git to
+# use it as well
+
+# black format
+0962f7378ceec1218e30489352df4c80533d4cb8


### PR DESCRIPTION
Solves the issue where it says [that most of the files was changed by @bw2](https://github.com/bw2/ConfigArgParse/blame/master/configargparse.py) in the [black commit](https://github.com/bw2/ConfigArgParse/commit/0962f7378ceec1218e30489352df4c80533d4cb8) -- this is something automatic inside of github, locally you will need to run the `git config ...` command mentioned in the file.