### PR TITLE
Adds .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# https://editorconfig.org/
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf
+charset = utf-8
+
+[*.py]
+max_line_length = 88
+
+[*.yml]
+indent_size = 2


### PR DESCRIPTION
# Please squash

[All modern editors](https://editorconfig.org/) now understand the `.editorconfig` standard. When you don't have one, the global settings of your editor are used. We can start with this, and go from here as a more defined standard is agreed on.