### PR TITLE
355 specify toml dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,9 @@ parser = configargparse.ArgParser(
 
 [TOML](https://github.com/toml-lang/toml/blob/main/toml.md) parser. This config parser can be used to integrate with `pyproject.toml` files.
 
-Requires installation of [toml](https://pypi.org/project/toml/) for Python versions below 3.11.
+Requires installation of [toml](https://pypi.org/project/toml/) for Python versions
+below 3.11, and for writing a config file out on any version, since the standard
+library's `tomllib` can only read.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Python's command line parsing modules such as argparse have very limited
 support for config files and environment variables, so this module
 extends argparse to add these features.
 
-**API docs:** https://bw2.github.io/ConfigArgParse/  
-  
+**API docs:** https://bw2.github.io/ConfigArgParse/
+
 **PyPI:** http://pypi.python.org/pypi/ConfigArgParse
 
 ## Install
@@ -158,14 +158,14 @@ Only command line args that have a long version (eg. one that starts with '--')
 can be set in a config file. For example, "--color" can be set by putting
 "color=green" in a config file. The config file syntax depends on the constructor
 arg: `config_file_parser_class` which can be set to one of the provided
-classes: 
+classes:
 - `DefaultConfigFileParser`
 - `YAMLConfigFileParser`
 - `ConfigparserConfigFileParser`
 - `IniConfigParser`
 - `TomlConfigParser`
 - `CompositeConfigParser`
-  
+
 or to your own subclass of the `ConfigFileParser` abstract class.
 
 #### *DefaultConfigFileParser* - the full range of valid syntax is:
@@ -332,6 +332,8 @@ parser = configargparse.ArgParser(
 
 [TOML](https://github.com/toml-lang/toml/blob/main/toml.md) parser. This config parser can be used to integrate with `pyproject.toml` files.
 
+Requires installation of [toml](https://pypi.org/project/toml/) for Python versions below 3.11.
+
 Example:
 
 ```toml
@@ -387,7 +389,7 @@ parser = configargparse.ArgParser(
 ...
 ```
 
-Note that it's required to put the TOML parser first because the INI syntax basically would accept anything whereas TOML.
+Note that it's required to put the TOML parser first because the INI syntax basically would accept anything whereas TOML is a bit more strict.
 
 ## ArgParser Singletons
 

--- a/configargparse.py
+++ b/configargparse.py
@@ -164,7 +164,7 @@ class ConfigFileParserException(Exception):
     """Raised when config file parsing failed."""
 
 
-class ConfigFileParserMissingDependency(Exception):
+class ConfigFileParserMissingDependency(ConfigFileParserException):
     """Raised when an optional dependency is missing."""
 
 
@@ -836,13 +836,15 @@ class CompositeConfigParser(ConfigFileParser):
         errors = []
         for i, p in enumerate(self.parsers):
             try:
-                print(f"USING PARSER {p.__class__.__name__}")
                 return p.parse(stream)  # type: ignore[no-any-return]
-            except ConfigFileParserMissingDependency as e:
-                msg = f"Cannot use parser {p.__class__.__name__} without optional dependency."
-                print(msg)
-                raise
             except Exception as e:
+                if isinstance(e, ConfigFileParserMissingDependency):
+                    # don't skip it silently, but don't take the rest of the
+                    # chain down with it either
+                    warnings.warn(
+                        f"Cannot use parser {p.__class__.__name__} without "
+                        f"optional dependency: {e}"
+                    )
                 errors.append(e)
                 # Try to seek back to beginning for next parser
                 # If this is not the last parser and seek fails, we can't continue
@@ -1738,9 +1740,9 @@ class ArgumentParser(argparse.ArgumentParser):
         if action is not None and isinstance(
             action, ACTION_TYPES_THAT_DONT_NEED_A_VALUE
         ):
-            assert isinstance(value, str), (
-                "config parser should convert anything that is not a list to string."
-            )
+            assert isinstance(
+                value, str
+            ), "config parser should convert anything that is not a list to string."
             if value.lower() in ("true", "yes", "on", "1"):
                 if not is_boolean_optional_action(action):
                     args.append(command_line_key)

--- a/configargparse.py
+++ b/configargparse.py
@@ -134,6 +134,10 @@ class ConfigFileParserException(Exception):
     """Raised when config file parsing failed."""
 
 
+class ConfigFileParserMissingDependency(Exception):
+    """Raised when an optional dependency is missing."""
+
+
 class DefaultConfigFileParser(ConfigFileParser):
     """
     Based on a simplified subset of INI and YAML formats. Here is the
@@ -316,7 +320,7 @@ class YAMLConfigFileParser(ConfigFileParser):
         try:
             import yaml
         except ImportError:
-            raise ConfigFileParserException(
+            raise ConfigFileParserMissingDependency(
                 "Could not import yaml. "
                 "It can be installed by running 'pip install PyYAML'"
             )
@@ -373,7 +377,7 @@ class YAMLConfigFileParser(ConfigFileParser):
 Provides `configargparse.ConfigFileParser` classes to parse ``TOML`` and ``INI`` files with **mandatory** support for sections.
 Useful to integrate configuration into project files like ``pyproject.toml`` or ``setup.cfg``.
 
-`TomlConfigParser` usage: 
+`TomlConfigParser` usage:
 
 >>> TomlParser = TomlConfigParser(['tool.my_super_tool']) # Simple TOML parser.
 >>> parser = ArgumentParser(..., default_config_files=['./pyproject.toml'], config_file_parser_class=TomlParser)
@@ -522,7 +526,15 @@ class TomlConfigParser(ConfigFileParser):
         """Parses the keys and values from a TOML config file."""
         # Use tomllib (Python 3.11+) if available, otherwise fall back to toml package
         try:
-            import tomllib
+            import tomllib as toml
+        except ImportError:
+            try:
+                import toml
+            except ImportError:
+                raise ConfigFileParserMissingDependency(
+                    "Could not import toml or tomllib. "
+                    "toml can be installed by running 'pip install toml'"
+                )
 
             # tomllib.load() requires binary mode, so use loads() for stream compatibility
             try:
@@ -530,15 +542,7 @@ class TomlConfigParser(ConfigFileParser):
                 # If content is bytes, decode it; if string, use as-is
                 if isinstance(content, bytes):
                     content = content.decode("utf-8")
-                config = tomllib.loads(content)
-            except Exception as e:
-                raise ConfigFileParserException("Couldn't parse TOML file: %s" % e)
-        except ImportError:
-            # Fall back to toml package (supports text mode)
-            import toml
-
-            try:
-                config = toml.load(stream)
+                config = toml.loads(content)
             except Exception as e:
                 raise ConfigFileParserException("Couldn't parse TOML file: %s" % e)
 
@@ -764,7 +768,7 @@ class CompositeConfigParser(ConfigFileParser):
 
     def __init__(self, config_parser_types):
         super().__init__()
-        self.parsers = [p() for p in config_parser_types]
+        self.parsers: list[ConfigFileParser] = [p() for p in config_parser_types]
 
     def __call__(self):
         return self
@@ -774,6 +778,9 @@ class CompositeConfigParser(ConfigFileParser):
         for i, p in enumerate(self.parsers):
             try:
                 return p.parse(stream)  # type: ignore[no-any-return]
+            except ConfigFileParserMissingDependency as e:
+                msg = f"Cannot use parser {p.__class__.__name__} without optional dependency."
+                raise ConfigFileParserMissingDependency(msg) from e
             except Exception as e:
                 errors.append(e)
                 # Try to seek back to beginning for next parser
@@ -804,7 +811,7 @@ class CompositeConfigParser(ConfigFileParser):
 
         msg = "Uses multiple config parser settings (in order): \n"
         for i, parser in enumerate(self.parsers):
-            msg += f"[{i+1}] {guess_format_name(parser.__class__.__name__)}: {parser.get_syntax_description()} \n"
+            msg += f"[{i + 1}] {guess_format_name(parser.__class__.__name__)}: {parser.get_syntax_description()} \n"
         return msg
 
     def serialize(self, items):
@@ -1447,9 +1454,9 @@ class ArgumentParser(argparse.ArgumentParser):
         if action is not None and isinstance(
             action, ACTION_TYPES_THAT_DONT_NEED_A_VALUE
         ):
-            assert isinstance(
-                value, str
-            ), "config parser should convert anything that is not a list to string."
+            assert isinstance(value, str), (
+                "config parser should convert anything that is not a list to string."
+            )
             if value.lower() in ("true", "yes", "on", "1"):
                 if not is_boolean_optional_action(action):
                     args.append(command_line_key)
@@ -1725,7 +1732,7 @@ class ArgumentParser(argparse.ArgumentParser):
                 added_config_file_help = True
 
                 msg += (
-                    "Args that start with '%s' can also be set in " "a config file"
+                    "Args that start with '%s' can also be set in a config file"
                 ) % cc
                 config_arg_string = " or ".join(
                     a.option_strings[0] for a in config_path_actions if a.option_strings
@@ -1832,15 +1839,13 @@ def add_argument(self, *args, **kwargs):
     if action.is_positional_arg and env_var:
         raise ValueError("env_var can't be set for a positional arg.")
     if action.is_config_file_arg and not isinstance(action, argparse._StoreAction):
-        raise ValueError("arg with is_config_file_arg=True must have " "action='store'")
+        raise ValueError("arg with is_config_file_arg=True must have action='store'")
     if action.is_write_out_config_file_arg:
         error_prefix = "arg with is_write_out_config_file_arg=True "
         if not isinstance(action, argparse._StoreAction):
             raise ValueError(error_prefix + "must have action='store'")
         if is_config_file_arg:
-            raise ValueError(
-                error_prefix + "can't also have " "is_config_file_arg=True"
-            )
+            raise ValueError(error_prefix + "can't also have is_config_file_arg=True")
 
     return action
 

--- a/configargparse.py
+++ b/configargparse.py
@@ -17,6 +17,7 @@ import sys
 import types
 from collections import OrderedDict
 import textwrap
+import warnings
 from io import StringIO
 
 ACTION_TYPES_THAT_DONT_NEED_A_VALUE = [
@@ -530,21 +531,21 @@ class TomlConfigParser(ConfigFileParser):
         except ImportError:
             try:
                 import toml
-            except ImportError:
+            except ImportError as e:
                 raise ConfigFileParserMissingDependency(
                     "Could not import toml or tomllib. "
                     "toml can be installed by running 'pip install toml'"
-                )
+                ) from e
 
-            # tomllib.load() requires binary mode, so use loads() for stream compatibility
-            try:
-                content = stream.read()
-                # If content is bytes, decode it; if string, use as-is
-                if isinstance(content, bytes):
-                    content = content.decode("utf-8")
-                config = toml.loads(content)
-            except Exception as e:
-                raise ConfigFileParserException("Couldn't parse TOML file: %s" % e)
+        # tomllib.load() requires binary mode, so use loads() for stream compatibility
+        try:
+            content = stream.read()
+            # If content is bytes, decode it; if string, use as-is
+            if isinstance(content, bytes):
+                content = content.decode("utf-8")
+            config = toml.loads(content)
+        except Exception as e:
+            raise ConfigFileParserException("Couldn't parse TOML file: %s" % e)
 
         # convert to dict and filter based on section names
         result = OrderedDict()
@@ -581,7 +582,7 @@ class TomlConfigParser(ConfigFileParser):
         try:
             import toml
         except ImportError:
-            raise ConfigFileParserException(
+            raise ConfigFileParserMissingDependency(
                 "The 'toml' package is required for TOML serialization. "
                 "Install it with: pip install toml"
             )
@@ -770,6 +771,19 @@ class CompositeConfigParser(ConfigFileParser):
         super().__init__()
         self.parsers: list[ConfigFileParser] = [p() for p in config_parser_types]
 
+        seen_ini = False
+        for parser in self.parsers:
+            if not seen_ini and isinstance(parser, IniConfigParser):
+                seen_ini = True
+                continue
+            if seen_ini and isinstance(parser, TomlConfigParser):
+                warnings.warn(
+                    "IniConfigParser was found before TomlConfigParser in parsers for "
+                    "CompositeConfigParser. This might lead to a TOML file being "
+                    "parsed as an INI file. Reorder the parsers.",
+                    category=SyntaxWarning,
+                )
+
     def __call__(self):
         return self
 
@@ -777,10 +791,12 @@ class CompositeConfigParser(ConfigFileParser):
         errors = []
         for i, p in enumerate(self.parsers):
             try:
+                print(f"USING PARSER {p.__class__.__name__}")
                 return p.parse(stream)  # type: ignore[no-any-return]
             except ConfigFileParserMissingDependency as e:
                 msg = f"Cannot use parser {p.__class__.__name__} without optional dependency."
-                raise ConfigFileParserMissingDependency(msg) from e
+                print(msg)
+                raise
             except Exception as e:
                 errors.append(e)
                 # Try to seek back to beginning for next parser

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ install_requires = []
 tests_require = [
     "black",
     "mock",
-    "toml; python_version < '3.11'",
+    "toml",
     "PyYAML",
     "pytest",
     "pytest-cov",
@@ -125,7 +125,7 @@ setup(
     install_requires=install_requires,
     tests_require=tests_require,
     extras_require={
-        "toml": ["toml; python_version < '3.11'"],
+        "toml": ["toml"],
         "yaml": ["PyYAML"],
         "test": tests_require,
     },

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,7 @@ def launch_http_server(directory):
             logging.debug("All network port. ")
     except Exception as e:
         logging.error(
-            "ERROR: while starting an HTTP server to serve "
-            "the coverage report: %s" % e
+            "ERROR: while starting an HTTP server to serve the coverage report: %s" % e
         )
 
 
@@ -82,7 +81,7 @@ install_requires = []
 tests_require = [
     "black",
     "mock",
-    "toml",
+    "toml; python_version < '3.11'",
     "PyYAML",
     "pytest",
     "pytest-cov",
@@ -126,6 +125,7 @@ setup(
     install_requires=install_requires,
     tests_require=tests_require,
     extras_require={
+        "toml": ["toml; python_version < '3.11'"],
         "yaml": ["PyYAML"],
         "test": tests_require,
     },

--- a/tests/test_configargparse.py
+++ b/tests/test_configargparse.py
@@ -14,7 +14,6 @@ import unittest
 from unittest import mock
 import warnings
 import textwrap
-import pytest
 
 from io import BytesIO, StringIO
 
@@ -1136,8 +1135,7 @@ class TestMisc(TestCase):
             r"%s:\n"
             r"  -h, --help\s+ show this help message and exit\n"
             rf"  -c{short_c}, --config CONFIG_FILE\s+ my config file\n"
-            r"  --genome GENOME\s+ Path to genome file\n\n"
-            % OPTIONAL_ARGS_STRING
+            r"  --genome GENOME\s+ Path to genome file\n\n" % OPTIONAL_ARGS_STRING
             + 5 * r"(.+\s*)",
         )
 
@@ -1219,8 +1217,7 @@ class TestMisc(TestCase):
             r"Config file syntax allows: key=value, flag=true, stuff=\[a,b,c\] "
             r"\(for details, see syntax at https://goo.gl/R74nmi\). "
             r"In general, command-line values override config file values "
-            r"which override defaults. ".replace(" ", r"\s*")
-            % OPTIONAL_ARGS_STRING,
+            r"which override defaults. ".replace(" ", r"\s*") % OPTIONAL_ARGS_STRING,
         )
 
     def test_FormatHelpProg(self):
@@ -3574,13 +3571,15 @@ class TestCompositeConfigParser(unittest.TestCase):
         with self.assertRaises(SystemExit):
             self.parser.parse_args([])
 
-    def test_composite_fails_if_missing_dependency(self):
+    def test_composite_warns_if_missing_dependency(self):
         self.write_yaml_file()
         self.write_ini_file()
 
         with mock.patch.dict(sys.modules, {"toml": None, "tomllib": None}):
-            with self.assertRaises(configargparse.ConfigFileParserMissingDependency):
-                self.parser.parse_args([])
+            with self.assertWarnsRegex(UserWarning, "TomlConfigParser"):
+                ns = self.parser.parse_args([])
+        # the parser that could not run is reported, but the chain still works
+        self.assertEqual(ns.key1, "ini1")
 
     def test_composite_warns_if_wrong_order(self):
         with self.assertWarns(SyntaxWarning):

--- a/tests/test_configargparse.py
+++ b/tests/test_configargparse.py
@@ -10,7 +10,9 @@ import tempfile
 import types
 import unittest
 from unittest import mock
+import warnings
 import textwrap
+import pytest
 
 from io import BytesIO, StringIO
 
@@ -2092,6 +2094,18 @@ class TestTomlConfigParser(unittest.TestCase):
         parser = configargparse.TomlConfigParser(["tool.section"])
         self.assertEqual(parser.parse(f), {"key1": "toml1", "key2": ["1", "2", "3"]})
 
+    def test_read_without_toml_packages(self):
+        f = self.write_toml_file("""
+            [tool.section]
+            key1 = "toml1"
+            key2 = [1, 2, 3]
+            """)
+        parser = configargparse.TomlConfigParser(["tool.section"])
+
+        with mock.patch.dict(sys.modules, {"toml": None, "tomllib": None}):
+            with self.assertRaises(configargparse.ConfigFileParserMissingDependency):
+                parser.parse(f)
+
     def test_binary_read_works(self):
         # Binary mode now works with tomllib (Python 3.11+)
         f = self.write_toml_file(
@@ -2143,7 +2157,7 @@ class TestTomlConfigParser(unittest.TestCase):
         import unittest.mock as mock
 
         with mock.patch.dict(sys.modules, {"toml": None}):
-            with self.assertRaises(configargparse.ConfigFileParserException):
+            with self.assertRaises(configargparse.ConfigFileParserMissingDependency):
                 parser.serialize(items)
 
 
@@ -2187,9 +2201,9 @@ class TestCompositeConfigParser(unittest.TestCase):
             default_config_files=["config.yaml", "config.toml", "config.ini"],
             config_file_parser_class=configargparse.CompositeConfigParser(
                 [
-                    configargparse.IniConfigParser(["section"], False),
                     configargparse.TomlConfigParser(["section"]),
                     configargparse.YAMLConfigFileParser,
+                    configargparse.IniConfigParser(["section"], False),
                 ]
             ),
         )
@@ -2281,6 +2295,23 @@ class TestCompositeConfigParser(unittest.TestCase):
         self.write_toml_file_extra()
         with self.assertRaises(SystemExit):
             self.parser.parse_args([])
+
+    def test_composite_fails_if_missing_dependency(self):
+        self.write_yaml_file()
+        self.write_ini_file()
+
+        with mock.patch.dict(sys.modules, {"toml": None, "tomllib": None}):
+            with self.assertRaises(configargparse.ConfigFileParserMissingDependency):
+                self.parser.parse_args([])
+
+    def test_composite_warns_if_wrong_order(self):
+        with self.assertWarns(SyntaxWarning):
+            composite = configargparse.CompositeConfigParser(
+                [
+                    configargparse.IniConfigParser(["section"], False),
+                    configargparse.TomlConfigParser(["section"]),
+                ]
+            )()
 
     def test_composite_serialize_delegates_to_first_parser(self):
         composite = configargparse.CompositeConfigParser(

--- a/tests/test_configargparse.py
+++ b/tests/test_configargparse.py
@@ -581,7 +581,7 @@ class TestBasicUseCases(TestCase):
         )
         self.assertRaisesRegex(
             ValueError,
-            "arg with " "is_write_out_config_file_arg=True must have action='store'",
+            "arg with is_write_out_config_file_arg=True must have action='store'",
             self.add_arg,
             "-y",
             "--Y",
@@ -1029,7 +1029,7 @@ class TestMisc(TestCase):
         self.assertEqual(p.prog, "prog")
         self.assertRaisesRegex(
             ValueError,
-            "kwargs besides 'name' can only be " "passed in the first time",
+            "kwargs besides 'name' can only be passed in the first time",
             configargparse.getArgumentParser,
             name,
             prog="prog",
@@ -1106,7 +1106,8 @@ class TestMisc(TestCase):
             r"%s:\n"
             r"  -h, --help\s+ show this help message and exit\n"
             rf"  -c{short_c}, --config CONFIG_FILE\s+ my config file\n"
-            r"  --genome GENOME\s+ Path to genome file\n\n" % OPTIONAL_ARGS_STRING
+            r"  --genome GENOME\s+ Path to genome file\n\n"
+            % OPTIONAL_ARGS_STRING
             + 5 * r"(.+\s*)",
         )
 
@@ -1188,7 +1189,8 @@ class TestMisc(TestCase):
             r"Config file syntax allows: key=value, flag=true, stuff=\[a,b,c\] "
             r"\(for details, see syntax at https://goo.gl/R74nmi\). "
             r"In general, command-line values override config file values "
-            r"which override defaults. ".replace(" ", r"\s*") % OPTIONAL_ARGS_STRING,
+            r"which override defaults. ".replace(" ", r"\s*")
+            % OPTIONAL_ARGS_STRING,
         )
 
     def test_FormatHelpProg(self):
@@ -1969,7 +1971,7 @@ class TestConfigFileParsers(TestCase):
             import yaml
         except:
             logging.warning(
-                "WARNING: PyYAML not installed. " "Couldn't test YAMLConfigFileParser"
+                "WARNING: PyYAML not installed. Couldn't test YAMLConfigFileParser"
             )
             return
 
@@ -1989,7 +1991,7 @@ class TestConfigFileParsers(TestCase):
             import yaml
         except:
             logging.warning(
-                "WARNING: PyYAML not installed. " "Couldn't test YAMLConfigFileParser"
+                "WARNING: PyYAML not installed. Couldn't test YAMLConfigFileParser"
             )
             return
 
@@ -2019,7 +2021,7 @@ class TestConfigFileParsers(TestCase):
             import yaml
         except:
             raise AssertionError(
-                "WARNING: PyYAML not installed. " "Couldn't test YAMLConfigFileParser"
+                "WARNING: PyYAML not installed. Couldn't test YAMLConfigFileParser"
             )
             return
 
@@ -2090,10 +2092,6 @@ class TestTomlConfigParser(unittest.TestCase):
         parser = configargparse.TomlConfigParser(["tool.section"])
         self.assertEqual(parser.parse(f), {"key1": "toml1", "key2": ["1", "2", "3"]})
 
-    @unittest.skipIf(
-        sys.version_info < (3, 11),
-        "Binary mode only supported with tomllib (Python 3.11+)",
-    )
     def test_binary_read_works(self):
         # Binary mode now works with tomllib (Python 3.11+)
         f = self.write_toml_file(
@@ -2104,20 +2102,6 @@ class TestTomlConfigParser(unittest.TestCase):
         parser = configargparse.TomlConfigParser(["tool.section"])
         # Should successfully parse binary stream
         self.assertEqual(parser.parse(f), {"key1": "toml1"})
-
-    @unittest.skipIf(
-        sys.version_info >= (3, 11),
-        "On Python 3.11+, tomllib handles binary; this tests the toml package fallback",
-    )
-    def test_binary_read_fails_without_tomllib(self):
-        # Without tomllib (Python < 3.11), binary streams should fail
-        f = self.write_toml_file(
-            b"""[section]\nkey1 = "toml1"\n""",
-            obj=BytesIO,
-        )
-        parser = configargparse.TomlConfigParser(["section"])
-        with self.assertRaises(configargparse.ConfigFileParserException):
-            parser.parse(f)
 
     def test_serialize_with_section(self):
         parser = configargparse.TomlConfigParser(["section"])


### PR DESCRIPTION
Specifies that `toml` is an optional dependency for python versions below 3.11.

Now raises different exceptions if `yaml` or `toml` cannot be imported in a `CompositeConfigParser`, so that it does not quietly fail.

Closes #355 (except that you may want to switch to `tomli`?)